### PR TITLE
fix(flake): update npmDepsHash to match new dependencies

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
           pname = "org-roam-ui-lite-node";
           version = packageJson.version;
           src = ./.;
-          npmDepsHash = "sha256-66+gI7CEm3LjwNXqYP/NLGcQnCM9j2X/Aer1Qua9ayo=";
+          npmDepsHash = "sha256-JkLiEzf2SuY9cxFxOD4sCSSbJ4ZVvUnKdZbrD42GUqY=";
           npmDeps = pkgs.fetchNpmDeps {
             inherit src;
             name = "${pname}-${version}-npm-deps";


### PR DESCRIPTION
When running nix run, I encountered the following error: 


```console
$ nix run github:tani/org-roam-ui-lite#export -- -d ~/.emacs.d/org-roam.db -o ./
[1/0/3 built, 0.1 MiB DL] building org-roam-ui-lite-node-0.0.13-npm-deps (buildPhase): Running phase: buildPhase

error: hash mismatch in fixed-output derivation '/nix/store/bmxb3s71dkpgh6j4wjqs7w5wgnhfq2gx-org-roam-ui-lite-node-0.0.13-npm-deps.drv':
         specified: sha256-66+gI7CEm3LjwNXqYP/NLGcQnCM9j2X/Aer1Qua9ayo=
            got:    sha256-JkLiEzf2SuY9cxFxOD4sCSSbJ4ZVvUnKdZbrD42GUqY=
error: 1 dependencies of derivation '/nix/store/54j2iziw08cfk0yk9g7zns7294fn0al7-org-roam-ui-lite-node-0.0.13.drv' failed to build
error: 1 dependencies of derivation '/nix/store/v860c5bx759lsidsq0psfhw7crxjdfsl-org-roam-ui-lite-export.drv' failed to build
$
```

2e24660017372bfaec1c432afdd2053c80e38d48 Update npmDepsHash

```console
$ nix run github:takeokunn/org-roam-ui-lite#export -- -d ~/.emacs.d/org-roam.db -o ./tmp

....

▶︎  Generating JSON API…
✅ All JSON files dumped to ./tmp/api
✅  Export finished.
$
```