### PR TITLE
Fix ts-ignore usage

### DIFF
--- a/packages/backend/src/database.ts
+++ b/packages/backend/src/database.ts
@@ -7,7 +7,6 @@ export type Database = SQLJsDatabase<typeof schema>;
 export async function createDatabase(db_path: string): Promise<Database> {
 	let SQL: SqlJsStatic;
 	try {
-		// @ts-ignore: import wasm as binary
 		const { default: wasmBinary } = await import("sql.js/dist/sql-wasm.wasm");
 		SQL = await initSqlJs({ wasmBinary });
 	} catch {

--- a/wasm.d.ts
+++ b/wasm.d.ts
@@ -1,0 +1,4 @@
+declare module "*.wasm" {
+	const wasmBinary: ArrayBuffer;
+	export default wasmBinary;
+}


### PR DESCRIPTION
## Summary
- remove `@ts-ignore` comments in backend code
- declare `*.wasm` module so database setup works without ignores
- type-check node dump pipeline instead of ignoring types

## Testing
- `npm run lint`
- `npm run check`
- `npm test` *(cancelled watcher)*