### PR TITLE
Add tests for util and backend

### DIFF
--- a/packages/backend/test/query.test.ts
+++ b/packages/backend/test/query.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { encodeBase64url } from "../src/base64url.ts";
+
+let mockReadFile: ReturnType<typeof vi.fn>;
+vi.mock("node:fs/promises", () => ({
+	readFile: (...args: unknown[]) => mockReadFile(...args),
+}));
+
+const NODE_ID = "11111111-1111-4111-8111-111111111111";
+const NODE_ID_2 = "22222222-2222-4222-8222-222222222222";
+
+function makeGraphDb() {
+	let call = 0;
+	return {
+		select: vi.fn(() => ({
+			from: vi.fn(() => {
+				call++;
+				if (call === 1) return [{ id: NODE_ID, title: "t" }];
+				return [
+					{
+						source: NODE_ID,
+						dest: NODE_ID_2,
+					},
+					{ source: NODE_ID, dest: "bad" },
+				];
+			}),
+		})),
+	};
+}
+
+function makeNodeDb(row: { id: string; title: string; file: string }) {
+	return {
+		select: vi.fn(() => ({
+			from: vi.fn(() => {
+				const first = {
+					innerJoin: vi.fn(() => first),
+					where: vi.fn(() => first),
+					get: vi.fn(() => row),
+				};
+				const second = {
+					innerJoin: vi.fn(() => second),
+					where: vi.fn(() => [{ source: "2", title: "back" }]),
+				};
+				if (!makeNodeDb.called) {
+					makeNodeDb.called = true;
+					return first;
+				}
+				return second;
+			}),
+		})),
+	};
+}
+makeNodeDb.called = false as unknown as boolean;
+
+function makeResourceDb(row: { id: string; title: string; file: string }) {
+	return {
+		select: vi.fn(() => ({
+			from: vi.fn(() => {
+				const chain = {
+					innerJoin: vi.fn(() => chain),
+					where: vi.fn(() => chain),
+					get: vi.fn(() => row),
+				};
+				return chain;
+			}),
+		})),
+	};
+}
+
+let mockCreateDatabase: ReturnType<typeof vi.fn>;
+vi.mock("../src/database.ts", () => ({
+	createDatabase: (...args: unknown[]) => mockCreateDatabase(...args),
+}));
+
+import { graph, node, resource } from "../src/query.ts";
+
+mockReadFile = vi.fn();
+mockCreateDatabase = vi.fn();
+
+describe("graph", () => {
+	it("filters invalid edges", async () => {
+		mockCreateDatabase.mockResolvedValue(makeGraphDb());
+		const result = await graph("x");
+		const body = result[1].content["application/json"];
+		expect(body.nodes).toHaveLength(1);
+		expect(body.edges).toEqual([
+			{
+				source: NODE_ID,
+				dest: NODE_ID_2,
+			},
+		]);
+	});
+});
+
+describe("node", () => {
+	it("returns node with backlinks and raw", async () => {
+		mockReadFile.mockResolvedValue("ORG");
+		makeNodeDb.called = false;
+		mockCreateDatabase.mockResolvedValue(
+			makeNodeDb({ id: NODE_ID, title: "t", file: "/tmp/a" }),
+		);
+		const result = await node("db", NODE_ID);
+		type NodeBody = {
+			id: string;
+			title: string;
+			raw: string;
+			backlinks: { source: string; title: string }[];
+		};
+		const body = result[1].content["application/json"] as NodeBody;
+		expect(body.id).toBe(NODE_ID);
+		expect(body.backlinks[0].source).toBe("2");
+		expect(body.raw).toBe("ORG");
+	});
+});
+
+describe("resource", () => {
+	it("reads resolved file", async () => {
+		const row = { id: NODE_ID, title: "t", file: "/base/file.org" };
+		mockCreateDatabase.mockResolvedValue(makeResourceDb(row));
+		const encoded = encodeBase64url("images/foo");
+		const full = `${encoded}.png`;
+		const buf = new Uint8Array([1, 2]);
+		mockReadFile.mockResolvedValue(buf);
+		const result = await resource("db", NODE_ID, full);
+		const body = (result[1].content as { [key: string]: Uint8Array })[
+			"image/*"
+		];
+		expect(body).toBe(buf);
+		expect(mockReadFile).toHaveBeenCalled();
+	});
+});

--- a/packages/frontend/test/util-extra.test.ts
+++ b/packages/frontend/test/util-extra.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+let mockGet: ReturnType<typeof vi.fn>;
+vi.mock("openapi-fetch", () => ({
+	default: vi.fn(() => ({ GET: (...args: unknown[]) => mockGet(...args) })),
+}));
+
+let mockCytoscape: ReturnType<typeof vi.fn>;
+vi.mock("cytoscape", () => ({
+	default: (...args: unknown[]) => mockCytoscape(...args),
+}));
+
+vi.mock("../src/processor.ts", () => ({
+	createOrgHtmlProcessor: vi.fn(
+		() => (str: string) => Promise.resolve(`html:${str}`),
+	),
+}));
+
+import { dimOthers, openNode, renderGraph } from "../src/util.ts";
+
+const NODE_ID = "11111111-1111-4111-8111-111111111111";
+
+mockGet = vi.fn();
+mockCytoscape = vi.fn();
+
+describe("dimOthers", () => {
+	it("sets opacity based on neighborhood", () => {
+		const node1 = { isNode: () => true, style: vi.fn() };
+		const node2 = { isNode: () => true, style: vi.fn() };
+		const edge = { isNode: () => false, style: vi.fn() };
+		const focus = { closedNeighborhood: vi.fn(() => new Set([node1, edge])) };
+		const graph = {
+			$id: vi.fn(() => focus),
+			elements: vi.fn(() => [node1, node2, edge]),
+		} as unknown as import("cytoscape").Core;
+		dimOthers(graph, "id");
+		expect(node1.style).toHaveBeenCalledWith("opacity", 1);
+		expect(edge.style).toHaveBeenCalledWith("opacity", 1);
+		expect(node2.style).toHaveBeenCalledWith("opacity", 0.15);
+	});
+
+	it("handles undefined graph", () => {
+		expect(() => dimOthers(undefined, "id")).not.toThrow();
+	});
+});
+
+describe("renderGraph", () => {
+	const container = document.createElement("div");
+	beforeEach(() => {
+		mockCytoscape.mockReset();
+		mockGet.mockReset();
+	});
+
+	it("creates new graph when none exists", async () => {
+		const cyInstance = {};
+		mockCytoscape.mockReturnValue(cyInstance);
+		mockGet.mockResolvedValue({
+			data: {
+				nodes: [{ id: NODE_ID, title: "Node" }],
+				edges: [],
+			},
+		});
+		const result = await renderGraph("cose", container, undefined, 10, 1);
+		expect(mockCytoscape).toHaveBeenCalled();
+		expect(result).toBe(cyInstance);
+	});
+
+	it("updates existing graph", async () => {
+		const existing = {
+			batch: vi.fn((cb: () => void) => cb()),
+			elements: vi.fn(() => ({ remove: vi.fn() })),
+			add: vi.fn(),
+			style: vi.fn(),
+			layout: vi.fn(() => ({ run: vi.fn() })),
+		} as unknown as import("cytoscape").Core;
+		mockGet.mockResolvedValue({
+			data: {
+				nodes: [],
+				edges: [],
+			},
+		});
+		const result = await renderGraph("fcose", container, existing, 5, 1);
+		expect(existing.batch).toHaveBeenCalled();
+		expect(result).toBe(existing);
+	});
+});
+
+describe("openNode", () => {
+	beforeEach(() => {
+		mockGet.mockReset();
+	});
+
+	it("fetches and processes node", async () => {
+		mockGet.mockResolvedValue({
+			data: { id: NODE_ID, title: "t", raw: "body" },
+		});
+		const result = await openNode("light", NODE_ID);
+		expect(result.html).toBe("html:body");
+		expect(result.id).toBe(NODE_ID);
+	});
+
+	it("throws on api error", async () => {
+		mockGet.mockResolvedValue({ data: {}, error: "oops" });
+		await expect(openNode("light", NODE_ID)).rejects.toBe("oops");
+	});
+});


### PR DESCRIPTION
## Summary
- add jsdom tests covering dimOthers, renderGraph and openNode in util.ts
- add backend query tests for graph, node and resource
- use UUID formatted ids in new tests

## Testing
- `npm run lint`
- `npm run check`
- `npx vitest run`
