### PR TITLE
Handle unknown languages safely

### DIFF
--- a/packages/frontend/src/processor.ts
+++ b/packages/frontend/src/processor.ts
@@ -71,9 +71,13 @@ export function createOrgHtmlProcessor<Theme extends string>(
 				themes: [theme.endsWith("dark") ? "vitesse-dark" : "vitesse-light"],
 			});
 			await Promise.all(
-				info.languages.map((l) =>
-					highlighter.loadLanguage(l as never).catch(() => {}),
-				),
+				info.languages.map(async (l) => {
+					try {
+						await highlighter.loadLanguage(l as never);
+					} catch {
+						/* ignore unknown languages */
+					}
+				}),
 			);
 			processor.use(rehypePrettyCode, {
 				theme: theme.endsWith("dark") ? "vitesse-dark" : "vitesse-light",

--- a/packages/frontend/test/processor.test.ts
+++ b/packages/frontend/test/processor.test.ts
@@ -101,4 +101,14 @@ describe("createOrgHtmlProcessor", () => {
 		expect(mockPrettyCode).toHaveBeenCalled();
 		expect(mockLoadLanguage).toHaveBeenCalledWith("js");
 	});
+
+	it("ignores unknown languages", async () => {
+		mockLoadLanguage.mockClear();
+		mockLoadLanguage.mockImplementationOnce(() => {
+			throw new Error("bad lang");
+		});
+		const org = "#+begin_src unknown\nfoo\n#+end_src";
+		await expect(createProcess()(org)).resolves.not.toThrow();
+		expect(mockLoadLanguage).toHaveBeenCalledWith("unknown");
+	});
 });


### PR DESCRIPTION
## Summary
- fall back when `loadLanguage` fails
- test that unknown languages are ignored

## Testing
- `npm run lint`
- `npm run check`
- `CI=1 npm test`
