### PR TITLE
Fix layout resets and keep original dimming

### DIFF
--- a/packages/frontend/src/app.tsx
+++ b/packages/frontend/src/app.tsx
@@ -38,6 +38,11 @@ function GraphView({
 }) {
 	const containerRef = useRef<HTMLDivElement>(null);
 	const graphRef = useRef<Core | undefined>(undefined);
+	const onOpenNodeRef = useRef(onOpenNode);
+
+	useEffect(() => {
+		onOpenNodeRef.current = onOpenNode;
+	}, [onOpenNode]);
 
 	useEffect(() => {
 		const container = containerRef.current;
@@ -53,13 +58,13 @@ function GraphView({
 			if (!mounted) return;
 			graphRef.current = g;
 			g.off("tap");
-			g.on("tap", "node", ({ target }) => onOpenNode(target.id()));
+			g.on("tap", "node", ({ target }) => onOpenNodeRef.current(target.id()));
 			onGraphReady(g);
 		});
 		return () => {
 			mounted = false;
 		};
-	}, [layout, nodeSize, labelScale, onOpenNode, onGraphReady]);
+	}, [layout, nodeSize, labelScale, onGraphReady]);
 
 	return <div ref={containerRef} id="graph" className="h-100 w-100"></div>;
 }

--- a/packages/frontend/test/node-details.test.tsx
+++ b/packages/frontend/test/node-details.test.tsx
@@ -62,5 +62,6 @@ describe("NodeDetails interaction", () => {
 		expect(util.setElementsStyle).toHaveBeenCalledWith(expect.anything(), {
 			opacity: 1,
 		});
+		expect(util.renderGraph).toHaveBeenCalledTimes(1);
 	});
 });


### PR DESCRIPTION
## Summary
- keep layout stable by referencing `onOpenNode` via ref
- retain original `dimOthers` behavior
- adjust util tests for reverted dimming
- format generated API definitions with Biome

## Testing
- `npm run lint`
- `npm run check`
- `npm test` (watch mode terminated)
