### PR TITLE
Switch offcanvas to Alpine.js

### DIFF
--- a/packages/frontend/src/app.ts
+++ b/packages/frontend/src/app.ts
@@ -1,6 +1,5 @@
 import persist from "@alpinejs/persist";
 import Alpine from "alpinejs";
-import * as bootstrap from "bootstrap";
 import type { Core } from "cytoscape";
 import type { components } from "./api.d.ts";
 import {
@@ -29,11 +28,10 @@ Alpine.data("app", () => ({
 	layouts: Layouts,
 	graph: undefined as Core | undefined,
 	selected: {} as components["schemas"]["Node"] & { html?: string },
-	offcanvas: undefined as bootstrap.Offcanvas | undefined,
+	settingsOpen: false,
+	detailsOpen: false,
 
 	async init() {
-		this.offcanvas = new bootstrap.Offcanvas(this.$refs.offcanvas);
-
 		// Initial graph render
 		this.graph = await renderGraph(
 			this.layout,
@@ -47,14 +45,6 @@ Alpine.data("app", () => ({
 		this.graph.on("tap", "node", ({ target }) => {
 			void this.openNode(target.id());
 		});
-
-		this.$refs.offcanvas.addEventListener("show.bs.offcanvas", () =>
-			dimOthers(this.graph, this.selected.id),
-		);
-
-		this.$refs.offcanvas.addEventListener("hidden.bs.offcanvas", () =>
-			setElementsStyle(this.graph, { opacity: 1 }),
-		);
 	},
 
 	// Refresh graph with current settings
@@ -92,7 +82,25 @@ Alpine.data("app", () => ({
 	async openNode(id: string) {
 		const selected = await openNode(this.theme, id);
 		this.selected = selected;
-		this.offcanvas?.show();
+		this.openDetails();
+	},
+
+	openDetails() {
+		this.detailsOpen = true;
+		dimOthers(this.graph, this.selected.id);
+	},
+
+	closeDetails() {
+		this.detailsOpen = false;
+		setElementsStyle(this.graph, { opacity: 1 });
+	},
+
+	toggleDetails() {
+		this.detailsOpen ? this.closeDetails() : this.openDetails();
+	},
+
+	toggleSettings() {
+		this.settingsOpen = !this.settingsOpen;
 	},
 }));
 

--- a/packages/frontend/src/index.html
+++ b/packages/frontend/src/index.html
@@ -25,6 +25,7 @@
 			tabindex="-1"
 			id="offcanvasSettings"
 			aria-labelledby="offcanvasSettingsLabel"
+			:class="{ show: settingsOpen }"
 		>
 			<div class="offcanvas-header">
 				<h4 class="offcanvas-title" id="offcanvasSettingsLabel">
@@ -33,7 +34,7 @@
 				<button
 					type="button"
 					class="btn-close"
-					data-bs-dismiss="offcanvas"
+					@click="settingsOpen = false"
 					aria-label="Close"
 				></button>
 			</div>
@@ -100,9 +101,7 @@
 			type="button"
 			class="btn btn-outline-secondary position-fixed"
 			style="top: 1rem; left: 1rem; z-index: 1;"
-			data-bs-toggle="offcanvas"
-			data-bs-target="#offcanvasSettings"
-			aria-controls="offcanvasSettings"
+			@click="toggleSettings()"
 		>
 			<i class="bi bi-gear"></i>
 		</button>
@@ -112,8 +111,8 @@
 			class="offcanvas offcanvas-end responsive-wide"
 			tabindex="-1"
 			id="offcanvasDetails"
-			x-ref="offcanvas"
 			aria-labelledby="offcanvasDetailsLabel"
+			:class="{ show: detailsOpen }"
 		>
 			<div class="offcanvas-header">
 				<h4 class="offcanvas-title" id="offcanvasDetailsLabel">
@@ -125,7 +124,7 @@
 				<button
 					type="button"
 					class="btn-close"
-					data-bs-dismiss="offcanvas"
+					@click="closeDetails()"
 					aria-label="Close"
 				></button>
 			</div>
@@ -158,9 +157,7 @@
 			type="button"
 			class="btn btn-outline-secondary position-fixed"
 			style="top: 1rem; right: 1rem; z-index: 1;"
-			data-bs-toggle="offcanvas"
-			data-bs-target="#offcanvasDetails"
-			aria-controls="offcanvasDetails"
+			@click="toggleDetails()"
 		>
 			<i class="bi bi-chevron-left"></i>
 		</button>


### PR DESCRIPTION
## Summary
- manage offcanvas visibility with Alpine state instead of Bootstrap JS
- adjust graph dimming when detail panel toggles
- format generated API definitions

## Testing
- `npm run lint`
- `npm run check`
- `npm test -- -w=false`
