### PR TITLE
docs: enforce style guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,3 +16,17 @@ Before submitting a PR, follow these steps:
 
 4. When opening a Pull Request, briefly describe the purpose of your
    changes and reference related modules or files.
+
+## Style Guide
+
+1. Use descriptive variable names. Keep singular and plural forms
+   consistent and avoid abbreviations. Prefer full words over short
+   forms.
+2. Start every function name with a verb so the intent is clear and use
+   a consistent casing style.
+3. Add a TSDoc block to **every** function. If the documentation fully
+   describes the code, remove the inline comments. Write any remaining
+   comments in English only.
+4. Explicitly declare the return type of every function.
+5. Follow the formatting rules from `biome.json`: tabs for indentation and
+   double quotes for strings.

--- a/openapi.ts
+++ b/openapi.ts
@@ -2,20 +2,27 @@ import openapiTS, {
 	astToString,
 	type SchemaObject,
 	type TransformNodeOptions,
+	type TransformObject,
 } from "openapi-typescript";
 import { factory } from "typescript";
 
+/**
+ * Map OpenAPI binary schema fields to Uint8Array types.
+ */
 const customTransform = (
 	schemaObject: SchemaObject,
 	_options: TransformNodeOptions,
-) => {
+): import("typescript").TypeNode | TransformObject | undefined => {
 	if (schemaObject.format === "binary") {
 		return factory.createTypeReferenceNode("Uint8Array");
 	}
 	return undefined;
 };
 
-async function generate() {
+/**
+ * Generate TypeScript types from the OpenAPI spec.
+ */
+async function generate(): Promise<void> {
 	const schemaUrl = new URL("./openapi.yaml", import.meta.url);
 	const ast = await openapiTS(schemaUrl, {
 		transform: customTransform,

--- a/packages/backend/src/base64url.ts
+++ b/packages/backend/src/base64url.ts
@@ -1,3 +1,9 @@
+/**
+ * Encode a string into URL-safe Base64.
+ *
+ * @param input - Text to encode
+ * @returns Encoded string without padding
+ */
 export function encodeBase64url(input: string): string {
 	const encoded = new TextEncoder().encode(input);
 	const binary = String.fromCharCode(...encoded);
@@ -5,6 +11,12 @@ export function encodeBase64url(input: string): string {
 	return base64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
 }
 
+/**
+ * Decode a URL-safe Base64 string.
+ *
+ * @param input - Text previously produced by {@link encodeBase64url}
+ * @returns Decoded UTF-8 string
+ */
 export function decodeBase64url(input: string): string {
 	let base64 = input.replace(/-/g, "+").replace(/_/g, "/");
 	const pad = base64.length % 4;

--- a/packages/backend/src/database.ts
+++ b/packages/backend/src/database.ts
@@ -4,6 +4,13 @@ import initSqlJs, { type SqlJsStatic } from "sql.js";
 import * as schema from "./schema.ts";
 
 export type Database = SQLJsDatabase<typeof schema>;
+
+/**
+ * Open the SQLite database and wrap it with Drizzle.
+ *
+ * @param db_path - Path to the database file
+ * @returns Drizzle connection bound to the schema
+ */
 export async function createDatabase(db_path: string): Promise<Database> {
 	let SQL: SqlJsStatic;
 	try {

--- a/packages/backend/src/query.ts
+++ b/packages/backend/src/query.ts
@@ -5,6 +5,12 @@ import type { paths } from "./api.d.ts";
 import { createDatabase } from "./database.ts";
 import { files, links, nodes } from "./schema.ts";
 
+/**
+ * Check whether the given value is a UUID string.
+ *
+ * @param str - Value to test
+ * @returns True if the value matches UUID format
+ */
 function isUuid(str: unknown): str is string {
 	const UUID_REGEX =
 		/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -14,6 +20,12 @@ function isUuid(str: unknown): str is string {
 type KVPair<T> = { [K in keyof T]: [K, T[K]] }[keyof T];
 
 type GraphResponse = KVPair<paths["/api/graph.json"]["get"]["responses"]>;
+
+/**
+ * Return the entire graph as nodes and edges.
+ *
+ * @param db_path - Path to the database
+ */
 export async function graph(db_path: string): Promise<GraphResponse> {
 	const db = await createDatabase(db_path);
 	const [ns, es] = await Promise.all([
@@ -26,7 +38,7 @@ export async function graph(db_path: string): Promise<GraphResponse> {
 		title: n.title,
 	}));
 
-	// dest が UUID のみ許可
+	// Only allow edges whose dest is a valid UUID
 	const cleanEdges = es
 		.filter((e) => isUuid(e.dest))
 		.map(({ source, dest }) => ({ source: source, dest: dest }));
@@ -46,6 +58,13 @@ export async function graph(db_path: string): Promise<GraphResponse> {
 }
 
 type NodeResponse = KVPair<paths["/api/node/{id}.json"]["get"]["responses"]>;
+
+/**
+ * Fetch a single node and its backlinks.
+ *
+ * @param db_path - Path to the database
+ * @param id - Node identifier
+ */
 export async function node(db_path: string, id: string): Promise<NodeResponse> {
 	const db = await createDatabase(db_path);
 	const row = db
@@ -101,6 +120,13 @@ export async function node(db_path: string, id: string): Promise<NodeResponse> {
 type ResourceResponse = KVPair<
 	paths["/api/node/{id}/{path}"]["get"]["responses"]
 >;
+/**
+ * Serve a binary resource attached to a node.
+ *
+ * @param db_path - Path to the database
+ * @param id - Node identifier
+ * @param encoded_path - Base64url encoded file name
+ */
 export async function resource(
 	db_path: string,
 	id: string,

--- a/packages/backend/src/serve.ts
+++ b/packages/backend/src/serve.ts
@@ -8,7 +8,13 @@ import { Hono } from "hono";
 import { lookup } from "mime-types";
 import { graph, node, resource } from "./query.ts";
 
-export async function serve(db_path: string, port: number) {
+/**
+ * Start the HTTP server serving the front-end and API.
+ *
+ * @param db_path - Path to the database
+ * @param port - TCP port to listen on
+ */
+export async function serve(db_path: string, port: number): Promise<void> {
 	const frontendDistPath = path.relative(
 		process.cwd(),
 		path.join(import.meta.dirname ?? "", "../../frontend/dist"),
@@ -16,7 +22,7 @@ export async function serve(db_path: string, port: number) {
 
 	const app = new Hono();
 
-	/* 静的ファイル (static/) */
+	/* Static files (frontend) */
 	app.use(
 		"/*",
 		serveStatic({
@@ -24,13 +30,13 @@ export async function serve(db_path: string, port: number) {
 		}),
 	);
 
-	/* ノード & エッジ一覧 */
+	/* Node and edge list */
 	app.get("/api/graph.json", async (c) => {
 		const [statusCode, response] = await graph(db_path);
 		return c.json(response.content["application/json"], statusCode);
 	});
 
-	/* ノード詳細 + Org ソース */
+	/* Node details including Org source */
 	app.get("/api/node/:id", async (c) => {
 		const id = c.req.param("id").replace(/\.json$/, "");
 		const [statusCode, response] = await node(db_path, id);

--- a/packages/frontend/src/app.ts
+++ b/packages/frontend/src/app.ts
@@ -31,6 +31,7 @@ Alpine.data("app", () => ({
 	settingsOpen: false,
 	detailsOpen: false,
 
+	/** Initialize the application and render the graph */
 	async init() {
 		// Initial graph render
 		this.graph = await renderGraph(
@@ -47,7 +48,7 @@ Alpine.data("app", () => ({
 		});
 	},
 
-	// Refresh graph with current settings
+	/** Re-render the graph with current settings */
 	async refresh() {
 		this.graph = await renderGraph(
 			this.layout,
@@ -58,47 +59,53 @@ Alpine.data("app", () => ({
 		);
 	},
 
+	/** Change layout and refresh the graph */
 	setLayout(newLayout: Layout) {
 		this.layout = newLayout;
 		void this.refresh();
 	},
 
-	// Toggle between dark/light theme
+	/** Switch between themes and refresh */
 	setTheme(newTheme: Theme) {
 		this.theme = newTheme;
 		void this.refresh();
 	},
 
-	// Called when node size slider changes
+	/** Adjust node size in the graph */
 	onSizeChange() {
 		setNodeStyle(this.graph, { width: this.nodeSize, height: this.nodeSize });
 	},
 
-	// Called when label scale slider changes
+	/** Adjust label scale in the graph */
 	onScaleChange() {
 		setNodeStyle(this.graph, { "font-size": `${this.labelScale}em` });
 	},
 
+	/** Fetch and display details for NODE ID */
 	async openNode(id: string) {
 		const selected = await openNode(this.theme, id);
 		this.selected = selected;
 		this.openDetails();
 	},
 
+	/** Show the details pane and dim other nodes */
 	openDetails() {
 		this.detailsOpen = true;
 		dimOthers(this.graph, this.selected.id);
 	},
 
+	/** Hide the details pane and restore styles */
 	closeDetails() {
 		this.detailsOpen = false;
 		setElementsStyle(this.graph, { opacity: 1 });
 	},
 
+	/** Toggle the details pane */
 	toggleDetails() {
 		this.detailsOpen ? this.closeDetails() : this.openDetails();
 	},
 
+	/** Toggle the settings pane */
 	toggleSettings() {
 		this.settingsOpen = !this.settingsOpen;
 	},

--- a/packages/frontend/src/base64url.ts
+++ b/packages/frontend/src/base64url.ts
@@ -1,3 +1,9 @@
+/**
+ * Encode a string into URL-safe Base64.
+ *
+ * @param input - Text to encode
+ * @returns Encoded string without padding
+ */
 export function encodeBase64url(input: string): string {
 	const encoded = new TextEncoder().encode(input);
 	const binary = String.fromCharCode(...encoded);
@@ -5,6 +11,12 @@ export function encodeBase64url(input: string): string {
 	return base64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
 }
 
+/**
+ * Decode a URL-safe Base64 string.
+ *
+ * @param input - Text previously produced by {@link encodeBase64url}
+ * @returns Decoded UTF-8 string
+ */
 export function decodeBase64url(input: string): string {
 	let base64 = input.replace(/-/g, "+").replace(/_/g, "/");
 	const pad = base64.length % 4;

--- a/packages/frontend/src/processor.ts
+++ b/packages/frontend/src/processor.ts
@@ -11,6 +11,12 @@ type Detect = {
 	languages: string[];
 };
 
+/**
+ * Inspect the Org string and determine which processors are needed.
+ *
+ * @param org - Org source text
+ * @returns Flags indicating required plugins
+ */
 function detect(org: string): Detect {
 	const langRe = /^#\+begin_src\s+(\S+)/gm;
 	const langs = new Set<string>();
@@ -29,6 +35,13 @@ function detect(org: string): Detect {
 
 type Process = (str: string) => Promise<string>;
 
+/**
+ * Create a processor that converts Org markup to HTML.
+ *
+ * @param theme - Color theme
+ * @param id - Node identifier used for resource links
+ * @returns Function that processes an Org string to HTML
+ */
 export function createOrgHtmlProcessor<Theme extends string>(
 	theme: Theme,
 	id: string,

--- a/packages/frontend/src/rehype-img-src-fix.ts
+++ b/packages/frontend/src/rehype-img-src-fix.ts
@@ -2,6 +2,12 @@ import type { Element, Root } from "hast";
 import { visit } from "unist-util-visit";
 import { encodeBase64url } from "./base64url.ts";
 
+/**
+ * Rewrite image src attributes to point to the resource API.
+ *
+ * @param id - Node identifier used in the URL
+ * @returns Transformer for the rehype pipeline
+ */
 export default function rehypeImgSrcFix(id: string) {
 	return (tree: Root) => {
 		visit(tree, "element", (node: Element) => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
 	test: {
-		// root のデフォルト環境は node のまま
+		// default environment for the root project
 		environment: "node",
 		coverage: {
 			enabled: true,
@@ -11,15 +11,15 @@ export default defineConfig({
 			include: ["packages/*/src/**"],
 		},
 
-		// 2つの inline プロジェクトを定義
+		// define two inline projects
 		projects: [
 			{
-				// root の設定（plugins など）を継承
+				// inherit root settings such as plugins
 				extends: true,
 				test: {
 					name: "frontend",
 					include: ["packages/frontend/test/**/*.test.ts"],
-					environment: "jsdom", // フロントエンドは jsdom
+					environment: "jsdom", // frontend uses jsdom
 				},
 			},
 			{
@@ -27,7 +27,7 @@ export default defineConfig({
 				test: {
 					name: "backend",
 					include: ["packages/backend/test/**/*.test.ts"],
-					environment: "node", // バックエンドは node
+					environment: "node", // backend uses node
 				},
 			},
 		],


### PR DESCRIPTION
## Summary
- expand style guide with naming and documentation rules
- add TSDoc comments and explicit return types across back-end and front-end modules
- translate comments to English and ensure formatting

## Testing
- `npm run lint`
- `npm run check`
