### PR TITLE
Refine variable names and function verbs

### DIFF
--- a/packages/backend/src/database.ts
+++ b/packages/backend/src/database.ts
@@ -8,10 +8,10 @@ export type Database = SQLJsDatabase<typeof schema>;
 /**
  * Open the SQLite database and wrap it with Drizzle.
  *
- * @param db_path - Path to the database file
+ * @param databasePath - Path to the database file
  * @returns Drizzle connection bound to the schema
  */
-export async function createDatabase(db_path: string): Promise<Database> {
+export async function createDatabase(databasePath: string): Promise<Database> {
 	let SQL: SqlJsStatic;
 	try {
 		const { default: wasmBinary } = await import("sql.js/dist/sql-wasm.wasm");
@@ -19,7 +19,7 @@ export async function createDatabase(db_path: string): Promise<Database> {
 	} catch {
 		SQL = await initSqlJs();
 	}
-	const blob = new Uint8Array(await fs.readFile(db_path));
+	const blob = new Uint8Array(await fs.readFile(databasePath));
 	const database = new SQL.Database(blob);
 	return drizzle(database, { schema });
 }

--- a/packages/backend/test/query.test.ts
+++ b/packages/backend/test/query.test.ts
@@ -73,15 +73,15 @@ vi.mock("../src/database.ts", () => ({
 	createDatabase: (...args: unknown[]) => mockCreateDatabase(...args),
 }));
 
-import { graph, node, resource } from "../src/query.ts";
+import { fetchGraph, fetchNode, fetchResource } from "../src/query.ts";
 
 mockReadFile = vi.fn();
 mockCreateDatabase = vi.fn();
 
-describe("graph", () => {
+describe("fetchGraph", () => {
 	it("filters invalid edges", async () => {
 		mockCreateDatabase.mockResolvedValue(makeGraphDb());
-		const result = await graph("x");
+		const result = await fetchGraph("x");
 		const body = result[1].content["application/json"];
 		expect(body.nodes).toHaveLength(1);
 		expect(body.edges).toEqual([
@@ -93,14 +93,14 @@ describe("graph", () => {
 	});
 });
 
-describe("node", () => {
+describe("fetchNode", () => {
 	it("returns node with backlinks and raw", async () => {
 		mockReadFile.mockResolvedValue("ORG");
 		makeNodeDb.called = false;
 		mockCreateDatabase.mockResolvedValue(
 			makeNodeDb({ id: NODE_ID, title: "t", file: "/tmp/a" }),
 		);
-		const result = await node("db", NODE_ID);
+		const result = await fetchNode("db", NODE_ID);
 		type NodeBody = {
 			id: string;
 			title: string;
@@ -114,7 +114,7 @@ describe("node", () => {
 	});
 });
 
-describe("resource", () => {
+describe("fetchResource", () => {
 	it("reads resolved file", async () => {
 		const row = { id: NODE_ID, title: "t", file: "/base/file.org" };
 		mockCreateDatabase.mockResolvedValue(makeResourceDb(row));
@@ -122,7 +122,7 @@ describe("resource", () => {
 		const full = `${encoded}.png`;
 		const buf = new Uint8Array([1, 2]);
 		mockReadFile.mockResolvedValue(buf);
-		const result = await resource("db", NODE_ID, full);
+		const result = await fetchResource("db", NODE_ID, full);
 		const body = (result[1].content as { [key: string]: Uint8Array })[
 			"image/*"
 		];

--- a/packages/frontend/src/app.ts
+++ b/packages/frontend/src/app.ts
@@ -82,8 +82,8 @@ Alpine.data("app", () => ({
 	},
 
 	/** Fetch and display details for NODE ID */
-	async openNode(id: string) {
-		const selected = await openNode(this.theme, id);
+	async openNode(nodeId: string) {
+		const selected = await openNode(this.theme, nodeId);
 		this.selected = selected;
 		this.openDetails();
 	},

--- a/packages/frontend/src/rehype-img-src-fix.ts
+++ b/packages/frontend/src/rehype-img-src-fix.ts
@@ -5,10 +5,10 @@ import { encodeBase64url } from "./base64url.ts";
 /**
  * Rewrite image src attributes to point to the resource API.
  *
- * @param id - Node identifier used in the URL
+ * @param nodeId - Node identifier used in the URL
  * @returns Transformer for the rehype pipeline
  */
-export default function rehypeImgSrcFix(id: string) {
+export default function rehypeImgSrcFix(nodeId: string): (tree: Root) => void {
 	return (tree: Root) => {
 		visit(tree, "element", (node: Element) => {
 			if (
@@ -16,22 +16,22 @@ export default function rehypeImgSrcFix(id: string) {
 				node.properties &&
 				typeof node.properties.src === "string"
 			) {
-				const src: string = node.properties.src;
+				const source: string = node.properties.src;
 				if (
-					src.startsWith("data:") ||
-					src.startsWith("http:") ||
-					src.startsWith("https:") ||
-					src.startsWith("//") ||
-					src.startsWith("/api/node/") ||
-					src.startsWith("#") ||
-					src.trim() === ""
+					source.startsWith("data:") ||
+					source.startsWith("http:") ||
+					source.startsWith("https:") ||
+					source.startsWith("//") ||
+					source.startsWith("/api/node/") ||
+					source.startsWith("#") ||
+					source.trim() === ""
 				) {
 					return;
 				}
-				const extname = src.replace(/^.*[.]/, ".");
-				const basename = src.replace(/[.][^.]*$/, "");
-				const encodedBasename = encodeBase64url(basename);
-				node.properties.src = `/api/node/${id}/${encodedBasename}${extname}`;
+				const extension = source.replace(/^.*[.]/, ".");
+				const baseName = source.replace(/[.][^.]*$/, "");
+				const encodedBaseName = encodeBase64url(baseName);
+				node.properties.src = `/api/node/${nodeId}/${encodedBaseName}${extension}`;
 			}
 		});
 	};

--- a/packages/frontend/src/util.ts
+++ b/packages/frontend/src/util.ts
@@ -33,13 +33,13 @@ export type Theme = (typeof Themes)[number]["value"];
  * @param name - CSS custom property name
  * @returns Resolved value
  */
-export function getCssVar(name: string): string {
+export function getCssVariable(name: string): string {
 	return getComputedStyle(document.documentElement)
 		.getPropertyValue(name)
 		.trim();
 }
 
-const ACCENT_VARS = [
+const ACCENT_VARIABLES = [
 	"--bs-blue",
 	"--bs-indigo",
 	"--bs-purple",
@@ -60,8 +60,9 @@ const ACCENT_VARS = [
  */
 export function pickColor(key: string): string {
 	let sum = 0;
-	for (const ch of key) sum = (sum + ch.charCodeAt(0)) % ACCENT_VARS.length;
-	return getCssVar(ACCENT_VARS[sum]);
+	for (const ch of key)
+		sum = (sum + ch.charCodeAt(0)) % ACCENT_VARIABLES.length;
+	return getCssVariable(ACCENT_VARIABLES[sum]);
 }
 
 /**
@@ -149,7 +150,7 @@ export async function renderGraph(
 				height: nodeSize,
 				"font-size": `${labelScale}em`,
 				label: "data(label)",
-				color: getCssVar("--bs-body-color"),
+				color: getCssVariable("--bs-body-color"),
 				"background-color": "data(color)",
 			},
 		},
@@ -193,15 +194,15 @@ export async function renderGraph(
  * Fetch a single node and convert its Org content to HTML.
  *
  * @param theme - Color theme
- * @param id - Node identifier
+ * @param nodeId - Node identifier
  * @returns Node information with rendered HTML
  */
 export async function openNode(
 	theme: Theme,
-	id: string,
+	nodeId: string,
 ): Promise<components["schemas"]["Node"] & { html: string }> {
 	const { data, error } = await api.GET("/api/node/{id}.json", {
-		params: { path: { id } },
+		params: { path: { id: nodeId } },
 	});
 
 	if (error) {
@@ -209,7 +210,7 @@ export async function openNode(
 	}
 
 	const { createOrgHtmlProcessor } = await import("./processor.ts");
-	const process = createOrgHtmlProcessor(theme, id);
+	const process = createOrgHtmlProcessor(theme, nodeId);
 	const html = String(await process(data.raw));
 	return { ...data, html };
 }

--- a/packages/frontend/test/app-utils.test.ts
+++ b/packages/frontend/test/app-utils.test.ts
@@ -1,13 +1,13 @@
 import type { Core } from "cytoscape";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
-	getCssVar,
+	getCssVariable,
 	pickColor,
 	setElementsStyle,
 	setNodeStyle,
 } from "../src/util.ts";
 
-const ACCENT_VARS = [
+const ACCENT_VARIABLES = [
 	"--bs-blue",
 	"--bs-indigo",
 	"--bs-purple",
@@ -23,20 +23,20 @@ const ACCENT_VARS = [
 beforeEach(() => {
 	// reset styles before each test
 	const style = document.documentElement.style;
-	for (const name of ACCENT_VARS) style.removeProperty(name);
+	for (const name of ACCENT_VARIABLES) style.removeProperty(name);
 	style.removeProperty("--foo");
 });
 
-describe("getCssVar", () => {
+describe("getCssVariable", () => {
 	it("returns trimmed css variable", () => {
 		document.documentElement.style.setProperty("--foo", "  bar  ");
-		expect(getCssVar("--foo")).toBe("bar");
+		expect(getCssVariable("--foo")).toBe("bar");
 	});
 });
 
 describe("pickColor", () => {
 	beforeEach(() => {
-		ACCENT_VARS.forEach((name) => {
+		ACCENT_VARIABLES.forEach((name) => {
 			document.documentElement.style.setProperty(
 				name,
 				name.replace("--bs-", ""),


### PR DESCRIPTION
## Summary
- use descriptive names like `databasePath` and `nodeId`
- rename API helpers to `fetchGraph`, `fetchNode`, and `fetchResource`
- update utils to expose `getCssVariable` and related constants
- adjust frontend handlers and tests to new names

## Testing
- `npm run lint`
- `npm run check`