### PR TITLE
Refactor front-end utils

### DIFF
--- a/packages/frontend/src/app.ts
+++ b/packages/frontend/src/app.ts
@@ -6,13 +6,13 @@ import {
 	dimOthers,
 	type Layout,
 	Layouts,
-	openNode,
 	renderGraph,
 	setElementsStyle,
 	setNodeStyle,
 	type Theme,
 	Themes,
-} from "./util.ts";
+} from "./graph.ts";
+import { openNode } from "./node.ts";
 
 Alpine.plugin(persist);
 

--- a/packages/frontend/src/node.ts
+++ b/packages/frontend/src/node.ts
@@ -1,0 +1,30 @@
+import createClient from "openapi-fetch";
+import type { components, paths } from "./api.d.ts";
+import type { Theme } from "./graph.ts";
+import { createOrgHtmlProcessor } from "./processor.ts";
+
+const api = createClient<paths>();
+
+/**
+ * Fetch a single node and convert its Org content to HTML.
+ *
+ * @param theme - Color theme
+ * @param nodeId - Node identifier
+ * @returns Node information with rendered HTML
+ */
+export async function openNode(
+	theme: Theme,
+	nodeId: string,
+): Promise<components["schemas"]["Node"] & { html: string }> {
+	const { data, error } = await api.GET("/api/node/{id}.json", {
+		params: { path: { id: nodeId } },
+	});
+
+	if (error) {
+		throw error;
+	}
+
+	const process = createOrgHtmlProcessor(theme, nodeId);
+	const html = String(await process(data.raw));
+	return { ...data, html };
+}

--- a/packages/frontend/src/style.ts
+++ b/packages/frontend/src/style.ts
@@ -1,0 +1,41 @@
+/**
+ * Utility functions for color and CSS variables.
+ */
+
+/**
+ * Read a CSS variable value.
+ *
+ * @param name - CSS custom property name
+ * @returns Resolved value
+ */
+export function getCssVariable(name: string): string {
+	return getComputedStyle(document.documentElement)
+		.getPropertyValue(name)
+		.trim();
+}
+
+const ACCENT_VARIABLES = [
+	"--bs-blue",
+	"--bs-indigo",
+	"--bs-purple",
+	"--bs-pink",
+	"--bs-red",
+	"--bs-orange",
+	"--bs-yellow",
+	"--bs-green",
+	"--bs-teal",
+	"--bs-cyan",
+] as const;
+
+/**
+ * Deterministically pick a color based on a string key.
+ *
+ * @param key - String used for color selection
+ * @returns CSS variable value
+ */
+export function pickColor(key: string): string {
+	let sum = 0;
+	for (const ch of key)
+		sum = (sum + ch.charCodeAt(0)) % ACCENT_VARIABLES.length;
+	return getCssVariable(ACCENT_VARIABLES[sum]);
+}

--- a/packages/frontend/test/app-utils.test.ts
+++ b/packages/frontend/test/app-utils.test.ts
@@ -1,11 +1,7 @@
 import type { Core } from "cytoscape";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-	getCssVariable,
-	pickColor,
-	setElementsStyle,
-	setNodeStyle,
-} from "../src/util.ts";
+import { setElementsStyle, setNodeStyle } from "../src/graph.ts";
+import { getCssVariable, pickColor } from "../src/style.ts";
 
 const ACCENT_VARIABLES = [
 	"--bs-blue",

--- a/packages/frontend/test/util-extra.test.ts
+++ b/packages/frontend/test/util-extra.test.ts
@@ -16,7 +16,8 @@ vi.mock("../src/processor.ts", () => ({
 	),
 }));
 
-import { dimOthers, openNode, renderGraph } from "../src/util.ts";
+import { dimOthers, renderGraph } from "../src/graph.ts";
+import { openNode } from "../src/node.ts";
 
 const NODE_ID = "11111111-1111-4111-8111-111111111111";
 


### PR DESCRIPTION
## Summary
- split util functions into distinct modules
- update app imports
- keep tests working with new module paths

## Testing
- `npm run lint`
- `npm run check`
- `npm test`
