### PR TITLE
Implement dim others for force graphs

### DIFF
--- a/packages/frontend/src/app.ts
+++ b/packages/frontend/src/app.ts
@@ -10,7 +10,7 @@ import {
 	type Renderer,
 	Renderers,
 	renderGraph,
-	setElementsStyle,
+	resetDim,
 	setNodeStyle,
 	type Theme,
 	Themes,
@@ -47,6 +47,10 @@ Alpine.data("app", () => ({
 			this.nodeSize,
 			this.labelScale,
 		);
+
+		this.$watch("renderer", () => {
+			void this.refresh();
+		});
 
 		// Event bindings
 		if (this.renderer === "cytoscape") {
@@ -92,7 +96,6 @@ Alpine.data("app", () => ({
 	/** Change renderer and refresh */
 	setRenderer(newRenderer: Renderer) {
 		this.renderer = newRenderer;
-		void this.refresh();
 	},
 
 	/** Switch between themes and refresh */
@@ -128,15 +131,13 @@ Alpine.data("app", () => ({
 	/** Show the details pane and dim other nodes */
 	openDetails() {
 		this.detailsOpen = true;
-		if (this.renderer === "cytoscape")
-			dimOthers(this.graph as Core, this.selected.id);
+		dimOthers(this.graph, this.selected.id);
 	},
 
 	/** Hide the details pane and restore styles */
 	closeDetails() {
 		this.detailsOpen = false;
-		if (this.renderer === "cytoscape")
-			setElementsStyle(this.graph as Core, { opacity: 1 });
+		resetDim(this.graph);
 	},
 
 	/** Toggle the details pane */

--- a/packages/frontend/src/graph.ts
+++ b/packages/frontend/src/graph.ts
@@ -3,7 +3,7 @@ import cytoscape, { type Core, type LayoutOptions } from "cytoscape";
 import ForceGraph from "force-graph";
 import createClient from "openapi-fetch";
 import type { paths } from "./api.d.ts";
-import { getCssVariable, pickColor } from "./style.ts";
+import { alphaColor, getCssVariable, pickColor } from "./style.ts";
 
 const api = createClient<paths>();
 
@@ -39,17 +39,59 @@ export type Renderer = (typeof Renderers)[number]["value"];
 /**
  * Dim unrelated nodes and edges leaving the focused node opaque.
  *
- * @param graph - Cytoscape instance
+ * @param graph - Graph instance
  * @param focusId - Node id to highlight
  */
-export function dimOthers(graph: Core | undefined, focusId: string): void {
+export function dimOthers(
+	graph: GraphInstance | undefined,
+	focusId: string,
+): void {
 	if (!graph) return;
-	const focus = graph.$id(focusId);
-	const neighborhood = focus?.closedNeighborhood();
-	graph.elements().forEach((el) => {
-		const isNeighbor = neighborhood.has(el);
-		el.style("opacity", isNeighbor ? 1 : el.isNode() ? 0.15 : 0.05);
+
+	// Cytoscape graph handling
+	if (typeof (graph as Core).elements === "function") {
+		const cy = graph as Core;
+		const focus = cy.$id(focusId);
+		const neighborhood = focus?.closedNeighborhood();
+		cy.elements().forEach((el) => {
+			const isNeighbor = neighborhood.has(el);
+			el.style("opacity", isNeighbor ? 1 : el.isNode() ? 0.15 : 0.05);
+		});
+		return;
+	}
+
+	// Force graph handling
+	const fg = graph as
+		| InstanceType<typeof ForceGraph>
+		| InstanceType<typeof ForceGraph3D>;
+	const data = fg.graphData();
+	const neighbors = new Set<string>([focusId]);
+	// biome-ignore lint/suspicious/noExplicitAny: external library types
+	(data.links as any[]).forEach((l: any) => {
+		const s = typeof l.source === "object" ? l.source.id : l.source;
+		const t = typeof l.target === "object" ? l.target.id : l.target;
+		if (s === focusId) neighbors.add(String(t));
+		if (t === focusId) neighbors.add(String(s));
 	});
+	const edgeColor = getCssVariable("--bs-secondary");
+	// biome-ignore lint/suspicious/noExplicitAny: external library types
+	const fgAny = fg as any;
+	fgAny.nodeColor(
+		// biome-ignore lint/suspicious/noExplicitAny: library callback
+		(node: any) =>
+			neighbors.has(String(node.id))
+				? node.color
+				: alphaColor(node.color, 0.15),
+	);
+	fgAny.linkColor(
+		// biome-ignore lint/suspicious/noExplicitAny: library callback
+		(link: any) => {
+			const s = typeof link.source === "object" ? link.source.id : link.source;
+			const t = typeof link.target === "object" ? link.target.id : link.target;
+			const related = neighbors.has(String(s)) && neighbors.has(String(t));
+			return related ? edgeColor : alphaColor(edgeColor, 0.05);
+		},
+	);
 }
 
 /**
@@ -78,6 +120,27 @@ export function setNodeStyle(
 	style: Record<string, unknown>,
 ): void {
 	graph?.nodes().style(style);
+}
+
+/**
+ * Restore default opacity and colors for all graph elements.
+ *
+ * @param graph - Graph instance
+ */
+export function resetDim(graph: GraphInstance | undefined): void {
+	if (!graph) return;
+	if (typeof (graph as Core).elements === "function") {
+		setElementsStyle(graph as Core, { opacity: 1 });
+		return;
+	}
+	const fg = graph as
+		| InstanceType<typeof ForceGraph>
+		| InstanceType<typeof ForceGraph3D>;
+	const edgeColor = getCssVariable("--bs-secondary");
+	// biome-ignore lint/suspicious/noExplicitAny: external library types
+	const fgAny = fg as any;
+	fgAny.nodeColor("color");
+	fgAny.linkColor(edgeColor);
 }
 
 /**
@@ -123,7 +186,12 @@ export async function renderGraph(
 		label: n.title,
 		color: pickColor(n.id),
 	}));
-	const edges = data.edges.map((e) => ({ source: e.source, target: e.dest }));
+	const edgeColor = getCssVariable("--bs-secondary");
+	const edges = data.edges.map((e) => ({
+		source: e.source,
+		target: e.dest,
+		color: edgeColor,
+	}));
 
 	if (renderer === "cytoscape") {
 		const elements = [
@@ -184,6 +252,7 @@ export async function renderGraph(
 			.nodeLabel("label")
 			.nodeColor("color")
 			.nodeRelSize(nodeSize / 10)
+			.linkColor("color")
 			.linkWidth(1)
 			.graphData({ nodes, links: edges });
 		return fg;
@@ -196,6 +265,7 @@ export async function renderGraph(
 		.nodeLabel("label")
 		.nodeColor("color")
 		.nodeRelSize(nodeSize / 10)
+		.linkColor("color")
 		.linkWidth(1)
 		.graphData({ nodes, links: edges });
 	return fg3d;

--- a/packages/frontend/src/style.ts
+++ b/packages/frontend/src/style.ts
@@ -39,3 +39,41 @@ export function pickColor(key: string): string {
 		sum = (sum + ch.charCodeAt(0)) % ACCENT_VARIABLES.length;
 	return getCssVariable(ACCENT_VARIABLES[sum]);
 }
+
+/**
+ * Convert a hex color string to rgba with the given alpha.
+ *
+ * @param color - Hex color like `#ff0000` or rgb string
+ * @param alpha - Alpha value between 0 and 1
+ * @returns RGBA color string
+ */
+export function alphaColor(color: string, alpha: number): string {
+	if (color.startsWith("#")) {
+		let hex = color.slice(1);
+		if (hex.length === 3)
+			hex = hex
+				.split("")
+				.map((c) => c + c)
+				.join("");
+		const r = parseInt(hex.slice(0, 2), 16);
+		const g = parseInt(hex.slice(2, 4), 16);
+		const b = parseInt(hex.slice(4, 6), 16);
+		return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+	}
+	if (color.startsWith("rgba")) {
+		const [r, g, b] = color
+			.replace(/rgba\(|\)/g, "")
+			.split(",")
+			.slice(0, 3)
+			.map((v) => Number(v.trim()));
+		return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+	}
+	if (color.startsWith("rgb")) {
+		const [r, g, b] = color
+			.replace(/rgb\(|\)/g, "")
+			.split(",")
+			.map((v) => Number(v.trim()));
+		return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+	}
+	return color;
+}

--- a/packages/frontend/test/util-extra.test.ts
+++ b/packages/frontend/test/util-extra.test.ts
@@ -14,7 +14,7 @@ let mockForceGraph: ReturnType<typeof vi.fn>;
 vi.mock("force-graph", () => ({
 	default: class {
 		constructor(...args: unknown[]) {
-			mockForceGraph(...args);
+			Object.assign(this, mockForceGraph(...args));
 		}
 	},
 }));
@@ -23,7 +23,7 @@ let mockForceGraph3D: ReturnType<typeof vi.fn>;
 vi.mock("3d-force-graph", () => ({
 	default: class {
 		constructor(...args: unknown[]) {
-			mockForceGraph3D(...args);
+			Object.assign(this, mockForceGraph3D(...args));
 		}
 	},
 }));
@@ -128,6 +128,7 @@ describe("renderGraph", () => {
 			nodeLabel: vi.fn(() => fgInstance),
 			nodeColor: vi.fn(() => fgInstance),
 			nodeRelSize: vi.fn(() => fgInstance),
+			linkColor: vi.fn(() => fgInstance),
 			linkWidth: vi.fn(() => fgInstance),
 		};
 		mockForceGraph.mockReturnValue(fgInstance);
@@ -141,7 +142,7 @@ describe("renderGraph", () => {
 			1,
 		);
 		expect(mockForceGraph).toHaveBeenCalledWith(container);
-		expect(result).toBe(fgInstance);
+		expect(result).toEqual(fgInstance);
 	});
 
 	it("creates 3d-force-graph instance", async () => {
@@ -151,6 +152,7 @@ describe("renderGraph", () => {
 			nodeLabel: vi.fn(() => fgInstance),
 			nodeColor: vi.fn(() => fgInstance),
 			nodeRelSize: vi.fn(() => fgInstance),
+			linkColor: vi.fn(() => fgInstance),
 			linkWidth: vi.fn(() => fgInstance),
 		} as unknown as object;
 		mockForceGraph3D.mockReturnValue(fgInstance);
@@ -164,7 +166,7 @@ describe("renderGraph", () => {
 			1,
 		);
 		expect(mockForceGraph3D).toHaveBeenCalledWith(container);
-		expect(result).toBe(fgInstance);
+		expect(result).toEqual(fgInstance);
 	});
 });
 


### PR DESCRIPTION
## Summary
- re-render graph whenever the renderer changes
- add `alphaColor` helper for rgba conversion
- dim neighbors in force-graph and 3d-force-graph
- restore styling with `resetDim`
- update force graph mocks in tests

## Testing
- `npm run lint`
- `npm run check`
- `npm test -- --run`
