### PR TITLE
Refactor graph module

### DIFF
--- a/packages/frontend/src/app.ts
+++ b/packages/frontend/src/app.ts
@@ -3,15 +3,15 @@ import Alpine from "alpinejs";
 import type { Core } from "cytoscape";
 import type { components } from "./api.d.ts";
 import {
-	dimOthers,
+	applyNodeStyle,
+	drawGraph,
 	type GraphInstance,
+	highlightNeighborhood,
 	type Layout,
 	Layouts,
 	type Renderer,
 	Renderers,
-	renderGraph,
-	resetDim,
-	setNodeStyle,
+	resetHighlight,
 	type Theme,
 	Themes,
 } from "./graph.ts";
@@ -57,7 +57,7 @@ Alpine.data("app", () => ({
 	/** Initialize the application and render the graph */
 	async init() {
 		// Initial graph render
-		this.graph = await renderGraph(
+		this.graph = await drawGraph(
 			this.renderer,
 			this.layout,
 			this.$refs.graph,
@@ -83,7 +83,7 @@ Alpine.data("app", () => ({
 
 	/** Re-render the graph with current settings */
 	async refresh() {
-		this.graph = await renderGraph(
+		this.graph = await drawGraph(
 			this.renderer,
 			this.layout,
 			this.$refs.graph,
@@ -116,7 +116,7 @@ Alpine.data("app", () => ({
 	/** Adjust node size in the graph */
 	onSizeChange() {
 		if (this.renderer === "cytoscape")
-			setNodeStyle(this.graph as Core, {
+			applyNodeStyle(this.graph as Core, {
 				width: this.nodeSize,
 				height: this.nodeSize,
 			});
@@ -126,7 +126,9 @@ Alpine.data("app", () => ({
 	/** Adjust label scale in the graph */
 	onScaleChange() {
 		if (this.renderer === "cytoscape")
-			setNodeStyle(this.graph as Core, { "font-size": `${this.labelScale}em` });
+			applyNodeStyle(this.graph as Core, {
+				"font-size": `${this.labelScale}em`,
+			});
 		else void this.refresh();
 	},
 
@@ -140,13 +142,13 @@ Alpine.data("app", () => ({
 	/** Show the details pane and dim other nodes */
 	openDetails() {
 		this.detailsOpen = true;
-		dimOthers(this.graph, this.selected.id);
+		highlightNeighborhood(this.graph, this.selected.id);
 	},
 
 	/** Hide the details pane and restore styles */
 	closeDetails() {
 		this.detailsOpen = false;
-		resetDim(this.graph);
+		resetHighlight(this.graph);
 	},
 
 	/** Toggle the details pane */

--- a/packages/frontend/test/app-utils.test.ts
+++ b/packages/frontend/test/app-utils.test.ts
@@ -1,6 +1,6 @@
 import type { Core } from "cytoscape";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { setElementsStyle, setNodeStyle } from "../src/graph.ts";
+import { applyElementsStyle, applyNodeStyle } from "../src/graph.ts";
 import { getCssVariable, pickColor } from "../src/style.ts";
 
 const ACCENT_VARIABLES = [
@@ -46,33 +46,33 @@ describe("pickColor", () => {
 	});
 });
 
-describe("setElementsStyle", () => {
+describe("applyElementsStyle", () => {
 	it("applies each style pair", () => {
 		const mockStyle = vi.fn();
 		const graph = {
 			elements: vi.fn(() => ({ style: mockStyle })),
 		} as unknown as Core;
-		setElementsStyle(graph, { width: 2, color: "red" });
+		applyElementsStyle(graph, { width: 2, color: "red" });
 		expect(mockStyle).toHaveBeenNthCalledWith(1, "width", 2);
 		expect(mockStyle).toHaveBeenNthCalledWith(2, "color", "red");
 	});
 
 	it("handles undefined graph", () => {
-		expect(() => setElementsStyle(undefined, { foo: 1 })).not.toThrow();
+		expect(() => applyElementsStyle(undefined, { foo: 1 })).not.toThrow();
 	});
 });
 
-describe("setNodeStyle", () => {
+describe("applyNodeStyle", () => {
 	it("applies style to nodes", () => {
 		const mockStyle = vi.fn();
 		const graph = {
 			nodes: vi.fn(() => ({ style: mockStyle })),
 		} as unknown as Core;
-		setNodeStyle(graph, { opacity: 0.5 });
+		applyNodeStyle(graph, { opacity: 0.5 });
 		expect(mockStyle).toHaveBeenCalledWith({ opacity: 0.5 });
 	});
 
 	it("handles undefined graph", () => {
-		expect(() => setNodeStyle(undefined, { foo: 1 })).not.toThrow();
+		expect(() => applyNodeStyle(undefined, { foo: 1 })).not.toThrow();
 	});
 });

--- a/packages/frontend/test/util-extra.test.ts
+++ b/packages/frontend/test/util-extra.test.ts
@@ -34,7 +34,7 @@ vi.mock("../src/processor.ts", () => ({
 	),
 }));
 
-import { dimOthers, renderGraph } from "../src/graph.ts";
+import { drawGraph, highlightNeighborhood } from "../src/graph.ts";
 import { openNode } from "../src/node.ts";
 
 const NODE_ID = "11111111-1111-4111-8111-111111111111";
@@ -44,7 +44,7 @@ mockCytoscape = vi.fn();
 mockForceGraph = vi.fn();
 mockForceGraph3D = vi.fn();
 
-describe("dimOthers", () => {
+describe("highlightNeighborhood", () => {
 	it("sets opacity based on neighborhood", () => {
 		const node1 = { isNode: () => true, style: vi.fn() };
 		const node2 = { isNode: () => true, style: vi.fn() };
@@ -54,18 +54,18 @@ describe("dimOthers", () => {
 			$id: vi.fn(() => focus),
 			elements: vi.fn(() => [node1, node2, edge]),
 		} as unknown as import("cytoscape").Core;
-		dimOthers(graph, "id");
+		highlightNeighborhood(graph, "id");
 		expect(node1.style).toHaveBeenCalledWith("opacity", 1);
 		expect(edge.style).toHaveBeenCalledWith("opacity", 1);
 		expect(node2.style).toHaveBeenCalledWith("opacity", 0.15);
 	});
 
 	it("handles undefined graph", () => {
-		expect(() => dimOthers(undefined, "id")).not.toThrow();
+		expect(() => highlightNeighborhood(undefined, "id")).not.toThrow();
 	});
 });
 
-describe("renderGraph", () => {
+describe("drawGraph", () => {
 	const container = document.createElement("div");
 	beforeEach(() => {
 		mockCytoscape.mockReset();
@@ -83,7 +83,7 @@ describe("renderGraph", () => {
 				edges: [],
 			},
 		});
-		const result = await renderGraph(
+		const result = await drawGraph(
 			"cytoscape",
 			"cose",
 			container,
@@ -109,7 +109,7 @@ describe("renderGraph", () => {
 				edges: [],
 			},
 		});
-		const result = await renderGraph(
+		const result = await drawGraph(
 			"cytoscape",
 			"fcose",
 			container,
@@ -134,7 +134,7 @@ describe("renderGraph", () => {
 		};
 		mockForceGraph.mockReturnValue(fgInstance);
 		mockGet.mockResolvedValue({ data: { nodes: [], edges: [] } });
-		const result = await renderGraph(
+		const result = await drawGraph(
 			"force-graph",
 			"cose",
 			container,
@@ -159,7 +159,7 @@ describe("renderGraph", () => {
 		} as unknown as object;
 		mockForceGraph3D.mockReturnValue(fgInstance);
 		mockGet.mockResolvedValue({ data: { nodes: [], edges: [] } });
-		const result = await renderGraph(
+		const result = await drawGraph(
 			"3d-force-graph",
 			"cose",
 			container,


### PR DESCRIPTION
## Summary
- reorganize graph.ts into focused helper functions
- rename graph utilities and update callers
- adjust tests for new function names

## Testing
- `npm run lint`
- `npm run check`
- `npm test -- --run`