### PR TITLE
Add preview popovers in node details

### DIFF
--- a/packages/frontend/src/app.css
+++ b/packages/frontend/src/app.css
@@ -64,9 +64,23 @@ html {
 	width: 90vw; /* xs: スマホ（〜575px） */
 }
 
+.preview-popover {
+	position: fixed;
+	z-index: 1070;
+	max-height: 75vh;
+	overflow: auto;
+}
+
+.preview-popover.responsive-wide {
+	width: 90vw;
+}
+
 /* sm: タブレット縦（576px〜767px） */
 @media (min-width: 576px) {
 	.offcanvas.offcanvas-end.responsive-wide {
+		width: 85vw;
+	}
+	.preview-popover.responsive-wide {
 		width: 85vw;
 	}
 }
@@ -76,6 +90,9 @@ html {
 	.offcanvas.offcanvas-end.responsive-wide {
 		width: 70vw;
 	}
+	.preview-popover.responsive-wide {
+		width: 70vw;
+	}
 }
 
 /* lg: ノートPC（992px〜1199px） */
@@ -83,11 +100,18 @@ html {
 	.offcanvas.offcanvas-end.responsive-wide {
 		width: 60vw;
 	}
+	.preview-popover.responsive-wide {
+		width: 60vw;
+	}
 }
 
 /* xl: デスクトップ以上（1200px〜） */
 @media (min-width: 1200px) {
 	.offcanvas.offcanvas-end.responsive-wide {
+		width: 50vw;
+		max-width: 800px;
+	}
+	.preview-popover.responsive-wide {
 		width: 50vw;
 		max-width: 800px;
 	}


### PR DESCRIPTION
## Summary
- show org node preview on hover in node details
- style preview popover using Bootstrap card
- size preview like the details panel across breakpoints

## Testing
- `npm run lint`
- `npm run check`
- `npm test -- --run`
