### PR TITLE
Remove web fonts and keep bootstrap icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -963,69 +963,6 @@
 				"node": ">=18"
 			}
 		},
-		"node_modules/@fontsource-variable/noto-sans": {
-			"version": "5.2.7",
-			"resolved": "https://registry.npmjs.org/@fontsource-variable/noto-sans/-/noto-sans-5.2.7.tgz",
-			"integrity": "sha512-VaA+clV7xTOx+pSOdyjr9nR7khjrJGr7ZHs2KXlx+AqLyG/SUVBadNwauCH0rvF/eZkZr67neNxdKMOLtVxweg==",
-			"license": "OFL-1.1",
-			"funding": {
-				"url": "https://github.com/sponsors/ayuhito"
-			}
-		},
-		"node_modules/@fontsource-variable/noto-sans-jp": {
-			"version": "5.2.5",
-			"resolved": "https://registry.npmjs.org/@fontsource-variable/noto-sans-jp/-/noto-sans-jp-5.2.5.tgz",
-			"integrity": "sha512-+ieDlugS+FCva2eLahVgybiaPMs1xLcBYByflzw1WghvFPFNJzsQHw85N+dadXzaqccVTiVDGYW4E0bMv4CHAQ==",
-			"license": "OFL-1.1",
-			"funding": {
-				"url": "https://github.com/sponsors/ayuhito"
-			}
-		},
-		"node_modules/@fontsource-variable/noto-sans-kr": {
-			"version": "5.2.5",
-			"resolved": "https://registry.npmjs.org/@fontsource-variable/noto-sans-kr/-/noto-sans-kr-5.2.5.tgz",
-			"integrity": "sha512-dIJyVPIBRJXtvaFmQ6GKCV93J9Fx3O2Ym5C3gDRcz5zLpEigrnlEfBnsXBUv4aDBHEF/gm/Q07d40dddGxFytg==",
-			"license": "OFL-1.1",
-			"funding": {
-				"url": "https://github.com/sponsors/ayuhito"
-			}
-		},
-		"node_modules/@fontsource-variable/noto-sans-mono": {
-			"version": "5.2.7",
-			"resolved": "https://registry.npmjs.org/@fontsource-variable/noto-sans-mono/-/noto-sans-mono-5.2.7.tgz",
-			"integrity": "sha512-qUqv/hB0linfL0IyDrqmkco3TcTunpdGgjvzuSfLPOYqcLxbc2zsMUhpyRPpUxjZbv6zvBGpoVcdh1Od5JxLrQ==",
-			"license": "OFL-1.1",
-			"funding": {
-				"url": "https://github.com/sponsors/ayuhito"
-			}
-		},
-		"node_modules/@fontsource-variable/noto-sans-sc": {
-			"version": "5.2.5",
-			"resolved": "https://registry.npmjs.org/@fontsource-variable/noto-sans-sc/-/noto-sans-sc-5.2.5.tgz",
-			"integrity": "sha512-TRxlLdbTMNq7XbTQN6XYsx8fdlg9MGZE5tVGzqCRi3audF4yugjino1NuwaKd5La+063qTSFXoRJf+sBv1ATXg==",
-			"license": "OFL-1.1",
-			"funding": {
-				"url": "https://github.com/sponsors/ayuhito"
-			}
-		},
-		"node_modules/@fontsource-variable/noto-sans-tc": {
-			"version": "5.2.5",
-			"resolved": "https://registry.npmjs.org/@fontsource-variable/noto-sans-tc/-/noto-sans-tc-5.2.5.tgz",
-			"integrity": "sha512-oaAn5hkLxraNBOWuiqyJ6+t1SmQ9Sszmcs+wJpmAmUO/1dsaHjDU5HXEjutvPpucqVeqdvVNr/kHRx+ghdiPeA==",
-			"license": "OFL-1.1",
-			"funding": {
-				"url": "https://github.com/sponsors/ayuhito"
-			}
-		},
-		"node_modules/@fontsource/noto-color-emoji": {
-			"version": "5.2.7",
-			"resolved": "https://registry.npmjs.org/@fontsource/noto-color-emoji/-/noto-color-emoji-5.2.7.tgz",
-			"integrity": "sha512-Q0slGKJIxhZvgIrPJ9bHtDMfd9l8s/MrIAalDYL1XalTTsrfHduAiIljlFG74zuaD7pDRDuEOdAFJOfqpu0PNg==",
-			"license": "OFL-1.1",
-			"funding": {
-				"url": "https://github.com/sponsors/ayuhito"
-			}
-		},
 		"node_modules/@fortawesome/fontawesome-free": {
 			"version": "6.7.2",
 			"resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.7.2.tgz",
@@ -2848,43 +2785,43 @@
 			"integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
 			"license": "ISC"
 		},
-		"node_modules/bootstrap": {
-			"version": "5.3.6",
-			"resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.6.tgz",
-			"integrity": "sha512-jX0GAcRzvdwISuvArXn3m7KZscWWFAf1MKBcnzaN02qWMb3jpMoUX4/qgeiGzqyIb4ojulRzs89UCUmGcFSzTA==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/twbs"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/bootstrap"
-				}
-			],
-			"license": "MIT",
-			"peerDependencies": {
-				"@popperjs/core": "^2.11.8"
-			}
-		},
-		"node_modules/bootstrap-icons": {
-			"version": "1.13.1",
-			"resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.13.1.tgz",
-			"integrity": "sha512-ijombt4v6bv5CLeXvRWKy7CuM3TRTuPEuGaGKvTV5cz65rQSY8RQ2JcHt6b90cBBAC7s8fsf2EkQDldzCoXUjw==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/twbs"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/bootstrap"
-				}
-			],
-			"license": "MIT"
-		},
-		"node_modules/brace-expansion": {
-			"version": "1.1.11",
+                "node_modules/bootstrap": {
+                        "version": "5.3.6",
+                        "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.6.tgz",
+                        "integrity": "sha512-jX0GAcRzvdwISuvArXn3m7KZscWWFAf1MKBcnzaN02qWMb3jpMoUX4/qgeiGzqyIb4ojulRzs89UCUmGcFSzTA==",
+                        "funding": [
+                                {
+                                        "type": "github",
+                                        "url": "https://github.com/sponsors/twbs"
+                                },
+                                {
+                                        "type": "opencollective",
+                                        "url": "https://opencollective.com/bootstrap"
+                                }
+                        ],
+                        "license": "MIT",
+                        "peerDependencies": {
+                                "@popperjs/core": "^2.11.8"
+                        }
+                },
+                "node_modules/bootstrap-icons": {
+                        "version": "1.13.1",
+                        "resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.13.1.tgz",
+                        "integrity": "sha512-ijombt4v6bv5CLeXvRWKy7CuM3TRTuPEuGaGKvTV5cz65rQSY8RQ2JcHt6b90cBBAC7s8fsf2EkQDldzCoXUjw==",
+                        "funding": [
+                                {
+                                        "type": "github",
+                                        "url": "https://github.com/sponsors/twbs"
+                                },
+                                {
+                                        "type": "opencollective",
+                                        "url": "https://opencollective.com/bootstrap"
+                                }
+                        ],
+                        "license": "MIT"
+                },
+                "node_modules/brace-expansion": {
+                        "version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 			"dev": true,
@@ -10950,19 +10887,12 @@
 			"name": "@org-roam-ui-lite/frontend",
 			"dependencies": {
 				"@alpinejs/persist": "^3.14.9",
-				"@fontsource-variable/noto-sans": "^5.2.7",
-				"@fontsource-variable/noto-sans-jp": "^5.2.5",
-				"@fontsource-variable/noto-sans-kr": "^5.2.5",
-				"@fontsource-variable/noto-sans-mono": "^5.2.7",
-				"@fontsource-variable/noto-sans-sc": "^5.2.5",
-				"@fontsource-variable/noto-sans-tc": "^5.2.5",
-				"@fontsource/noto-color-emoji": "^5.2.7",
 				"@rehype-pretty/transformers": "^0.13.2",
 				"3d-force-graph": "^1.77.0",
 				"alpinejs": "^3.14.9",
-				"bootstrap": "^5.3.5",
-				"bootstrap-icons": "^1.11.3",
-				"cytoscape": "^3.31.4",
+                                "bootstrap": "^5.3.5",
+                                "bootstrap-icons": "^1.11.3",
+                                "cytoscape": "^3.31.4",
 				"force-graph": "^1.49.6",
 				"openapi-fetch": "^0.13.5",
 				"rehype-class-names": "^2.0.0",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -8,13 +8,7 @@
 	},
 	"dependencies": {
 		"@alpinejs/persist": "^3.14.9",
-		"@fontsource-variable/noto-sans": "^5.2.7",
-		"@fontsource-variable/noto-sans-jp": "^5.2.5",
-		"@fontsource-variable/noto-sans-kr": "^5.2.5",
-		"@fontsource-variable/noto-sans-mono": "^5.2.7",
-		"@fontsource-variable/noto-sans-sc": "^5.2.5",
-		"@fontsource-variable/noto-sans-tc": "^5.2.5",
-		"@fontsource/noto-color-emoji": "^5.2.7",
+
 		"@rehype-pretty/transformers": "^0.13.2",
 		"3d-force-graph": "^1.77.0",
 		"alpinejs": "^3.14.9",

--- a/packages/frontend/src/app.css
+++ b/packages/frontend/src/app.css
@@ -2,24 +2,52 @@
 @import url("./code.css");
 @import url("bootstrap/dist/css/bootstrap.min.css");
 @import url("bootstrap-icons/font/bootstrap-icons.css");
-@import url("@fontsource/noto-color-emoji");
-@import url("@fontsource-variable/noto-sans");
-@import url("@fontsource-variable/noto-sans-jp");
-@import url("@fontsource-variable/noto-sans-kr");
-@import url("@fontsource-variable/noto-sans-sc");
-@import url("@fontsource-variable/noto-sans-tc");
-@import url("@fontsource-variable/noto-sans-mono");
+/* Removed webfonts */
 
 :root {
-	--bs-font-monospace: "Noto Sans Mono Variable", /* Japanese */
-		"Noto Sans JP Variable", /* Korean */ "Noto Sans KR Variable", /* Traditional Chinese (繁体字) */
-		"Noto Sans TC Variable", /* Simplified Chinese (簡体字) */
-		"Noto Sans SC Variable", /* fallback */ monospace, /* Emoji */
+	--bs-font-monospace:
+		ui-monospace,
+		SFMono-Regular,
+		Menlo,
+		Monaco,
+		Consolas,
+		"Liberation Mono",
+		"Noto Sans Mono",
+		"Noto Sans Mono CJK JP",
+		"Noto Sans Mono CJK KR",
+		"Noto Sans Mono CJK SC",
+		"Noto Sans Mono CJK TC",
+		monospace,
+		"Apple Color Emoji",
+		"Segoe UI Emoji",
+		"Segoe UI Symbol",
 		"Noto Color Emoji";
-	--bs-font-sans-serif: "Noto Sans Variable", /* Japanese */
-		"Noto Sans JP Variable", /* Korean */ "Noto Sans KR Variable", /* Traditional Chinese (繁体字) */
-		"Noto Sans TC Variable", /* Simplified Chinese (簡体字) */
-		"Noto Sans SC Variable", /* fallback */ sans-serif, /* Emoji */
+	--bs-font-sans-serif:
+		system-ui,
+		-apple-system,
+		BlinkMacSystemFont,
+		"Segoe UI",
+		Roboto,
+		"Helvetica Neue",
+		Arial,
+		"Noto Sans",
+		"Hiragino Sans",
+		"Hiragino Kaku Gothic ProN",
+		"Meiryo",
+		"MS PGothic",
+		"Malgun Gothic",
+		"Apple SD Gothic Neo",
+		"PingFang SC",
+		"PingFang TC",
+		"Noto Sans CJK JP",
+		"Noto Sans CJK KR",
+		"Noto Sans CJK SC",
+		"Noto Sans CJK TC",
+		"Source Han Sans",
+		sans-serif,
+		"Apple Color Emoji",
+		"Segoe UI Emoji",
+		"Segoe UI Symbol",
 		"Noto Color Emoji";
 	--h-scale-ratio: 1.08;
 	--h-base-size: 1rem;


### PR DESCRIPTION
## Summary
- keep Bootstrap icon font instead of local SVG icons
- switch fonts to a CJK-friendly system stack

## Testing
- `npm run lint`
- `npm run check`
- `npm test -- --run`
