### PR TITLE
Add label toggles for all graph renderers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2785,43 +2785,43 @@
 			"integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
 			"license": "ISC"
 		},
-                "node_modules/bootstrap": {
-                        "version": "5.3.6",
-                        "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.6.tgz",
-                        "integrity": "sha512-jX0GAcRzvdwISuvArXn3m7KZscWWFAf1MKBcnzaN02qWMb3jpMoUX4/qgeiGzqyIb4ojulRzs89UCUmGcFSzTA==",
-                        "funding": [
-                                {
-                                        "type": "github",
-                                        "url": "https://github.com/sponsors/twbs"
-                                },
-                                {
-                                        "type": "opencollective",
-                                        "url": "https://opencollective.com/bootstrap"
-                                }
-                        ],
-                        "license": "MIT",
-                        "peerDependencies": {
-                                "@popperjs/core": "^2.11.8"
-                        }
-                },
-                "node_modules/bootstrap-icons": {
-                        "version": "1.13.1",
-                        "resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.13.1.tgz",
-                        "integrity": "sha512-ijombt4v6bv5CLeXvRWKy7CuM3TRTuPEuGaGKvTV5cz65rQSY8RQ2JcHt6b90cBBAC7s8fsf2EkQDldzCoXUjw==",
-                        "funding": [
-                                {
-                                        "type": "github",
-                                        "url": "https://github.com/sponsors/twbs"
-                                },
-                                {
-                                        "type": "opencollective",
-                                        "url": "https://opencollective.com/bootstrap"
-                                }
-                        ],
-                        "license": "MIT"
-                },
-                "node_modules/brace-expansion": {
-                        "version": "1.1.11",
+		"node_modules/bootstrap": {
+			"version": "5.3.6",
+			"resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.6.tgz",
+			"integrity": "sha512-jX0GAcRzvdwISuvArXn3m7KZscWWFAf1MKBcnzaN02qWMb3jpMoUX4/qgeiGzqyIb4ojulRzs89UCUmGcFSzTA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/twbs"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/bootstrap"
+				}
+			],
+			"license": "MIT",
+			"peerDependencies": {
+				"@popperjs/core": "^2.11.8"
+			}
+		},
+		"node_modules/bootstrap-icons": {
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.13.1.tgz",
+			"integrity": "sha512-ijombt4v6bv5CLeXvRWKy7CuM3TRTuPEuGaGKvTV5cz65rQSY8RQ2JcHt6b90cBBAC7s8fsf2EkQDldzCoXUjw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/twbs"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/bootstrap"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/brace-expansion": {
+			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 			"dev": true,
@@ -10890,9 +10890,9 @@
 				"@rehype-pretty/transformers": "^0.13.2",
 				"3d-force-graph": "^1.77.0",
 				"alpinejs": "^3.14.9",
-                                "bootstrap": "^5.3.5",
-                                "bootstrap-icons": "^1.11.3",
-                                "cytoscape": "^3.31.4",
+				"bootstrap": "^5.3.5",
+				"bootstrap-icons": "^1.11.3",
+				"cytoscape": "^3.31.4",
 				"force-graph": "^1.49.6",
 				"openapi-fetch": "^0.13.5",
 				"rehype-class-names": "^2.0.0",

--- a/packages/frontend/src/app.ts
+++ b/packages/frontend/src/app.ts
@@ -27,6 +27,7 @@ Alpine.data("app", () => ({
 	),
 	nodeSize: 10,
 	labelScale: 0.5,
+	showLabels: Alpine.$persist<boolean>(true),
 	layout: Alpine.$persist<Layout>("cose"),
 	layouts: Layouts,
 	renderers: Renderers,
@@ -66,6 +67,7 @@ Alpine.data("app", () => ({
 			this.graph,
 			this.nodeSize,
 			this.labelScale,
+			this.showLabels,
 		);
 
 		this.bindGraphEvents();
@@ -94,6 +96,7 @@ Alpine.data("app", () => ({
 			this.graph,
 			this.nodeSize,
 			this.labelScale,
+			this.showLabels,
 		);
 
 		this.bindGraphEvents();
@@ -134,6 +137,11 @@ Alpine.data("app", () => ({
 				"font-size": `${this.labelScale}em`,
 			});
 		else void this.refresh();
+	},
+
+	/** Toggle label visibility */
+	onShowLabelsChange() {
+		void this.refresh();
 	},
 
 	/** Fetch and display details for NODE ID */

--- a/packages/frontend/src/graph.ts
+++ b/packages/frontend/src/graph.ts
@@ -183,6 +183,7 @@ async function renderWithCytoscape(
 	existing: Core | undefined,
 	nodeSize: number,
 	labelScale: number,
+	showLabels: boolean,
 ): Promise<Core> {
 	const { default: cytoscape } = await import("cytoscape");
 	const elements = [
@@ -198,7 +199,7 @@ async function renderWithCytoscape(
 				width: nodeSize,
 				height: nodeSize,
 				"font-size": `${labelScale}em`,
-				label: "data(label)",
+				label: showLabels ? "data(label)" : "",
 				"font-family": getCssVariable("--bs-font-sans-serif"),
 				color: getCssVariable("--bs-body-color"),
 				"background-color": "data(color)",
@@ -242,12 +243,15 @@ async function renderWithForceGraph(
 	container: HTMLElement,
 	existing: ForceGraph<GraphNode, GraphLink> | undefined,
 	nodeSize: number,
+	labelScale: number,
+	showLabels: boolean,
 ): Promise<ForceGraph<GraphNode, GraphLink>> {
 	const { default: ForceGraphCtor } = await import("force-graph");
 	const radius = nodeSize / 2;
 	const area = Math.PI * radius * radius;
 	const fgNodes = nodes.map((n) => ({ ...n, val: area }));
 	if (!existing) existing = new ForceGraphCtor<GraphNode, GraphLink>(container);
+	const fontSize = 12 * labelScale;
 	existing
 		.nodeId("id")
 		.nodeLabel("label")
@@ -257,6 +261,22 @@ async function renderWithForceGraph(
 		.linkColor("color")
 		.linkWidth(2)
 		.graphData({ nodes: fgNodes, links: edges });
+
+	if (showLabels)
+		existing
+			.nodeCanvasObject((node: GraphNode, ctx, scale) => {
+				const label = String(node.label);
+				const size = fontSize / scale;
+				ctx.font = `${size}px ${getCssVariable("--bs-font-sans-serif")}`;
+				ctx.textAlign = "center";
+				ctx.textBaseline = "top";
+				ctx.fillStyle = getCssVariable("--bs-body-color");
+				if (typeof node.x === "number" && typeof node.y === "number")
+					ctx.fillText(label, node.x, node.y + radius + 2);
+			})
+			.nodeCanvasObjectMode(() => "after");
+	else existing.nodeCanvasObject(() => undefined);
+
 	return existing;
 }
 
@@ -267,7 +287,10 @@ async function renderWith3DForceGraph(
 	container: HTMLElement,
 	existing: ForceGraph3DInstance<GraphNode, GraphLink> | undefined,
 	nodeSize: number,
+	labelScale: number,
+	showLabels: boolean,
 ): Promise<ForceGraph3DInstance<GraphNode, GraphLink>> {
+	void labelScale;
 	const { default: ForceGraph3D } = await import("3d-force-graph");
 	const radius = nodeSize / 2;
 	const volume = (4 / 3) * Math.PI * radius * radius * radius;
@@ -277,15 +300,18 @@ async function renderWith3DForceGraph(
 			GraphNode,
 			GraphLink
 		>;
+	existing.backgroundColor(getCssVariable("--bs-body-bg"));
 	existing
 		.nodeId("id")
-		.nodeLabel("label")
 		.nodeColor("color")
 		.nodeVal("val")
 		.nodeRelSize(1)
 		.linkColor("color")
 		.linkWidth(2)
 		.graphData({ nodes: fgNodes, links: edges });
+
+	existing.nodeLabel(showLabels ? "label" : "");
+	if (!showLabels) existing.nodeThreeObject(null).nodeThreeObjectExtend(false);
 	return existing;
 }
 
@@ -299,6 +325,7 @@ export async function drawGraph(
 	existingGraph: GraphInstance | undefined,
 	nodeSize: number,
 	labelScale: number,
+	showLabels: boolean,
 ): Promise<GraphInstance> {
 	const { nodes, edges } = await fetchGraphData();
 
@@ -311,6 +338,7 @@ export async function drawGraph(
 			existingGraph as Core | undefined,
 			nodeSize,
 			labelScale,
+			showLabels,
 		);
 
 	if (renderer === "force-graph")
@@ -320,6 +348,8 @@ export async function drawGraph(
 			container,
 			existingGraph as ForceGraph<GraphNode, GraphLink> | undefined,
 			nodeSize,
+			labelScale,
+			showLabels,
 		);
 
 	return renderWith3DForceGraph(
@@ -328,5 +358,7 @@ export async function drawGraph(
 		container,
 		existingGraph as ForceGraph3DInstance<GraphNode, GraphLink> | undefined,
 		nodeSize,
+		labelScale,
+		showLabels,
 	);
 }

--- a/packages/frontend/src/index.html
+++ b/packages/frontend/src/index.html
@@ -109,6 +109,21 @@
 						Current: <span x-text="labelScale.toFixed(1)"></span>em
 					</div>
 				</div>
+				<div class="mb-4">
+					<h5>Show labels</h5>
+					<div class="form-check form-switch">
+						<input
+							class="form-check-input"
+							type="checkbox"
+							id="toggleLabels"
+							x-model="showLabels"
+							@change="onShowLabelsChange()"
+						>
+						<label class="form-check-label" for="toggleLabels">
+							Display labels
+						</label>
+					</div>
+				</div>
 			</div>
 		</div>
 

--- a/packages/frontend/test/util-extra.test.ts
+++ b/packages/frontend/test/util-extra.test.ts
@@ -90,6 +90,7 @@ describe("drawGraph", () => {
 			undefined,
 			10,
 			1,
+			true,
 		);
 		expect(mockCytoscape).toHaveBeenCalled();
 		expect(result).toBe(cyInstance);
@@ -116,6 +117,7 @@ describe("drawGraph", () => {
 			existing,
 			5,
 			1,
+			true,
 		);
 		expect(existing.batch).toHaveBeenCalled();
 		expect(result).toBe(existing);
@@ -131,6 +133,8 @@ describe("drawGraph", () => {
 			nodeRelSize: vi.fn(() => fgInstance),
 			linkColor: vi.fn(() => fgInstance),
 			linkWidth: vi.fn(() => fgInstance),
+			nodeCanvasObject: vi.fn(() => fgInstance),
+			nodeCanvasObjectMode: vi.fn(() => fgInstance),
 		};
 		mockForceGraph.mockReturnValue(fgInstance);
 		mockGet.mockResolvedValue({ data: { nodes: [], edges: [] } });
@@ -141,6 +145,7 @@ describe("drawGraph", () => {
 			undefined,
 			5,
 			1,
+			true,
 		);
 		expect(mockForceGraph).toHaveBeenCalledWith(container);
 		expect(result).toEqual(fgInstance);
@@ -156,7 +161,10 @@ describe("drawGraph", () => {
 			nodeRelSize: vi.fn(() => fgInstance),
 			linkColor: vi.fn(() => fgInstance),
 			linkWidth: vi.fn(() => fgInstance),
-		} as unknown as object;
+			backgroundColor: vi.fn(() => fgInstance),
+			nodeThreeObject: vi.fn(() => fgInstance),
+			nodeThreeObjectExtend: vi.fn(() => fgInstance),
+		} as unknown as Record<string, unknown>;
 		mockForceGraph3D.mockReturnValue(fgInstance);
 		mockGet.mockResolvedValue({ data: { nodes: [], edges: [] } });
 		const result = await drawGraph(
@@ -166,8 +174,10 @@ describe("drawGraph", () => {
 			undefined,
 			5,
 			1,
+			true,
 		);
 		expect(mockForceGraph3D).toHaveBeenCalledWith(container);
+		expect(fgInstance.backgroundColor).toHaveBeenCalled();
 		expect(result).toEqual(fgInstance);
 	});
 });


### PR DESCRIPTION
## Summary
- show node labels above `force-graph` nodes
- allow toggling label visibility for cytoscape, force-graph and 3D
- expose UI control for label toggle
- adjust tests and resolve lint warnings
- change 3D graph background color to match current theme

## Testing
- `npm run lint`
- `npm run check`
- `npm test -- --run`
