### PR TITLE
Refactor to remove unnecessary casts

### DIFF
--- a/packages/backend/src/dump.ts
+++ b/packages/backend/src/dump.ts
@@ -74,7 +74,7 @@ async function dumpNodeJsons(
 		if ("raw" in json) {
 			const parsed = processor.parse(json.raw);
 			// unified@10+ run returns Node, but our pipeline yields a HAST Root
-			const tree = (await processor.run(parsed)) as unknown as Root;
+			const tree = (await processor.run(parsed)) as Root;
 
 			const imageSources: string[] = [];
 			visit(tree, "element", (node: Element) => {

--- a/packages/backend/test/query.test.ts
+++ b/packages/backend/test/query.test.ts
@@ -10,6 +10,8 @@ vi.mock("node:fs/promises", () => ({
 const NODE_ID = "11111111-1111-4111-8111-111111111111";
 const NODE_ID_2 = "22222222-2222-4222-8222-222222222222";
 
+let makeNodeDbCalled = false;
+
 function makeGraphDb() {
 	let call = 0;
 	return {
@@ -42,8 +44,8 @@ function makeNodeDb(row: { id: string; title: string; file: string }) {
 					innerJoin: vi.fn(() => second),
 					where: vi.fn(() => [{ source: "2", title: "back" }]),
 				};
-				if (!makeNodeDb.called) {
-					makeNodeDb.called = true;
+				if (!makeNodeDbCalled) {
+					makeNodeDbCalled = true;
 					return first;
 				}
 				return second;
@@ -51,7 +53,6 @@ function makeNodeDb(row: { id: string; title: string; file: string }) {
 		})),
 	};
 }
-makeNodeDb.called = false as unknown as boolean;
 
 function makeResourceDb(row: { id: string; title: string; file: string }) {
 	return {
@@ -96,7 +97,7 @@ describe("fetchGraph", () => {
 describe("fetchNode", () => {
 	it("returns node with backlinks and raw", async () => {
 		mockReadFile.mockResolvedValue("ORG");
-		makeNodeDb.called = false;
+		makeNodeDbCalled = false;
 		mockCreateDatabase.mockResolvedValue(
 			makeNodeDb({ id: NODE_ID, title: "t", file: "/tmp/a" }),
 		);

--- a/packages/frontend/src/App.vue
+++ b/packages/frontend/src/App.vue
@@ -108,9 +108,10 @@ function bindGraphEvents(): void {
 			void openNodeAction(target.id());
 		});
 	} else {
-		const fg = graph.value as unknown as {
-			onNodeClick: (cb: (node: { id: string }) => void) => void;
-		};
+		interface ClickableGraph {
+			onNodeClick(cb: (node: { id: string }) => void): void;
+		}
+		const fg = graph.value as ClickableGraph;
 		fg.onNodeClick((node: { id: string }) => {
 			void openNodeAction(node.id);
 		});

--- a/packages/frontend/src/renderers/cytoscape.ts
+++ b/packages/frontend/src/renderers/cytoscape.ts
@@ -71,7 +71,7 @@ const renderCytoscape: RendererFunction = async (
 			minZoom: 0.5,
 			maxZoom: 4,
 			style,
-		}) as unknown as GraphInstance;
+		});
 	}
 
 	cyExisting.batch(() => {

--- a/packages/frontend/src/renderers/force-graph.ts
+++ b/packages/frontend/src/renderers/force-graph.ts
@@ -60,7 +60,7 @@ const renderForceGraph: RendererFunction = async (
 		}).nodeCanvasObjectMode(() => "after");
 	else fg.nodeCanvasObject(() => undefined).nodeCanvasObjectMode(() => "after");
 
-	return fg as unknown as GraphInstance;
+	return fg;
 };
 
 export default renderForceGraph;


### PR DESCRIPTION
## Summary
- reduce `as unknown as` in the source
- keep state for mock database with a variable
- type the graph click handler
- drop cast when creating cytoscape and force-graph graphs

## Testing
- `npm run lint`
- `npm run check`
- `npm test -- --run`