### PR TITLE
Add missing frontend tests

### DIFF
--- a/packages/frontend/test/graph-edge-color.test.ts
+++ b/packages/frontend/test/graph-edge-color.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGet = vi.fn();
+vi.mock("openapi-fetch", () => ({
+	default: vi.fn(() => ({ GET: (...args: unknown[]) => mockGet(...args) })),
+}));
+
+const mockRenderer = vi.fn(async (..._args: unknown[]) => ({}));
+vi.mock("../src/renderers/cytoscape.ts", () => ({
+	default: (...args: unknown[]) => mockRenderer(...args),
+}));
+
+import { drawGraph } from "../src/graph.ts";
+
+beforeEach(() => {
+	mockGet.mockReset();
+	mockRenderer.mockReset();
+});
+
+describe("drawGraph", () => {
+	it("applies edge color from css variable", async () => {
+		document.documentElement.style.setProperty("--bs-secondary", "gray");
+		mockGet.mockResolvedValue({
+			data: {
+				nodes: [{ id: "1", title: "n" }],
+				edges: [{ source: "1", dest: "2" }],
+			},
+		});
+		await drawGraph(
+			"cytoscape",
+			"cose",
+			document.createElement("div"),
+			undefined,
+			10,
+			1,
+			true,
+		);
+		const edges = (mockRenderer.mock.calls[0] as unknown[])[1] as Array<{
+			color: string;
+		}>;
+		expect(edges[0].color).toBe("gray");
+	});
+});

--- a/packages/frontend/test/main.test.ts
+++ b/packages/frontend/test/main.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it, vi } from "vitest";
+
+let mount: ReturnType<typeof vi.fn>;
+vi.mock("vue", async (importActual) => {
+	const actual = await importActual<typeof import("vue")>();
+	mount = vi.fn();
+	return { ...actual, createApp: vi.fn(() => ({ mount })) };
+});
+
+describe("startApp", () => {
+	it("mounts Vue app", async () => {
+		const mod = await import("../src/main.ts");
+		mount.mockClear();
+		const app = mod.startApp();
+		expect(mount).toHaveBeenCalledWith("#app");
+		expect(app).toEqual({ mount });
+	});
+});


### PR DESCRIPTION
## Summary
- add coverage-focused tests for Vue app logic
- verify DetailsPanel link handling and preview mouseout
- cover edge color construction in graph utilities
- test the main entrypoint

## Testing
- `npm run lint`
- `npm run check`
- `npm test -- --run`