### PR TITLE
Use gitignore for ESLint

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -4,11 +4,10 @@ import {
   vueTsConfigs,
 } from "@vue/eslint-config-typescript";
 import prettier from "@vue/eslint-config-prettier";
+import gitignore from "eslint-config-flat-gitignore";
 
 export default defineConfigWithVueTs(
-  {
-    ignores: ["out/**", "**/dist/**", "node_modules/**", "openapi.ts"],
-  },
+  gitignore(),
   pluginVue.configs["flat/essential"],
   vueTsConfigs.recommended,
   prettier,

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@vue/eslint-config-typescript": "^14.5.0",
     "eslint": "^9.27.0",
     "eslint-plugin-vue": "^10.1.0",
+    "eslint-config-flat-gitignore": "^0.2.1",
     "jsdom": "^26.1.0",
     "lefthook": "^1.11.12",
     "license-checker": "^25.0.1",


### PR DESCRIPTION
## Summary
- remove custom ignores from ESLint configuration
- use `eslint-config-flat-gitignore` to read ignore patterns
- add dependency in `package.json`

## Testing
- `npm run lint` *(fails: Cannot find module 'eslint-config-flat-gitignore')*
- `npm run check`
- `npm test -- --run`
