### PR TITLE
Simplify settings handling with v-model

### DIFF
--- a/packages/frontend/src/App.vue
+++ b/packages/frontend/src/App.vue
@@ -3,23 +3,18 @@
     <div ref="graphRef" class="h-100 w-100"></div>
 
     <SettingsPanel
+      v-model:theme="theme"
+      v-model:renderer="renderer"
+      v-model:layout="layout"
+      v-model:node-size="nodeSize"
+      v-model:label-scale="labelScale"
+      v-model:show-labels="showLabels"
       :open="settingsOpen"
       :themes="themes"
-      :theme="theme"
       :renderers="renderers"
-      :renderer="renderer"
       :layouts="layouts"
-      :layout="layout"
-      :node-size="nodeSize"
-      :label-scale="labelScale"
-      :show-labels="showLabels"
-      @close="store.toggleSettings()"
-      @update:theme="setTheme"
-      @update:renderer="setRenderer"
       @update:layout="setLayout"
-      @update:node-size="onSizeChange"
-      @update:label-scale="onScaleChange"
-      @update:show-labels="onShowLabelsChange"
+      @close="store.toggleSettings()"
     />
 
     <button
@@ -67,9 +62,7 @@ import {
   type GraphInstance,
   type Layout,
   Layouts,
-  type Renderer,
   Renderers,
-  type Theme,
   Themes,
 } from "./graph-types.ts";
 import { openNode } from "./node.ts";
@@ -152,45 +145,6 @@ function setLayout(newLayout: Layout): void {
   void refresh();
 }
 
-/** Change renderer and refresh. */
-function setRenderer(newRenderer: Renderer): void {
-  store.renderer = newRenderer;
-  graph.value = undefined;
-}
-
-/** Switch between themes and refresh. */
-function setTheme(newTheme: Theme): void {
-  store.theme = newTheme;
-  void refresh();
-}
-
-/** Adjust node size in the graph. */
-function onSizeChange(value: number): void {
-  store.nodeSize = value;
-  if (renderer.value === "cytoscape")
-    applyNodeStyle(graph.value as Core, {
-      width: value,
-      height: value,
-    });
-  else void refresh();
-}
-
-/** Adjust label scale in the graph. */
-function onScaleChange(value: number): void {
-  store.labelScale = value;
-  if (renderer.value === "cytoscape")
-    applyNodeStyle(graph.value as Core, {
-      "font-size": `${value}em`,
-    });
-  else void refresh();
-}
-
-/** Toggle label visibility. */
-function onShowLabelsChange(value: boolean): void {
-  store.showLabels = value;
-  void refresh();
-}
-
 /** Fetch and display details for node ID. */
 async function openNodeAction(nodeId: string): Promise<void> {
   const node = await openNode(theme.value, nodeId);
@@ -228,6 +182,28 @@ watch(renderer, () => {
   graph.value = undefined;
   void refresh();
 });
+watch(theme, () => {
+  void refresh();
+});
+watch(nodeSize, (value) => {
+  if (renderer.value === "cytoscape")
+    applyNodeStyle(graph.value as Core, {
+      width: value,
+      height: value,
+    });
+  else void refresh();
+});
 
+watch(labelScale, (value) => {
+  if (renderer.value === "cytoscape")
+    applyNodeStyle(graph.value as Core, {
+      "font-size": `${value}em`,
+    });
+  else void refresh();
+});
+
+watch(showLabels, () => {
+  void refresh();
+});
 onMounted(init);
 </script>

--- a/packages/frontend/src/components/SettingsPanel.vue
+++ b/packages/frontend/src/components/SettingsPanel.vue
@@ -36,7 +36,11 @@
       </div>
       <div v-show="rendererModel === 'cytoscape'" class="mb-4">
         <h5>Layout</h5>
-        <select v-model="layoutModel" class="form-select">
+        <select
+          v-model="layoutModel"
+          class="form-select"
+          @change="$emit('update:layout', layoutModel)"
+        >
           <option v-for="l in layouts" :key="l" :value="l">{{ l }}</option>
         </select>
       </div>
@@ -81,59 +85,25 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
+import { defineModel } from "vue";
 import type { Layout, Renderer, Theme } from "../graph-types.ts";
 
-const props = defineProps<{
+defineProps<{
   open: boolean;
   themes: { value: Theme; label: string }[];
   renderers: { value: Renderer; label: string }[];
   layouts: Layout[];
-  theme: Theme;
-  renderer: Renderer;
-  layout: Layout;
-  nodeSize: number;
-  labelScale: number;
-  showLabels: boolean;
 }>();
 
-const emit = defineEmits<{
+const themeModel = defineModel<Theme>("theme");
+const rendererModel = defineModel<Renderer>("renderer");
+const layoutModel = defineModel<Layout>("layout");
+const nodeSizeModel = defineModel<number>("nodeSize");
+const labelScaleModel = defineModel<number>("labelScale");
+const showLabelsModel = defineModel<boolean>("showLabels");
+
+defineEmits<{
   (e: "close"): void;
-  (e: "update:theme", value: Theme): void;
-  (e: "update:renderer", value: Renderer): void;
   (e: "update:layout", value: Layout): void;
-  (e: "update:nodeSize", value: number): void;
-  (e: "update:labelScale", value: number): void;
-  (e: "update:showLabels", value: boolean): void;
 }>();
-
-const themeModel = computed({
-  get: () => props.theme,
-  set: (value: Theme) => emit("update:theme", value),
-});
-
-const rendererModel = computed({
-  get: () => props.renderer,
-  set: (value: Renderer) => emit("update:renderer", value),
-});
-
-const layoutModel = computed({
-  get: () => props.layout,
-  set: (value: Layout) => emit("update:layout", value),
-});
-
-const nodeSizeModel = computed({
-  get: () => props.nodeSize,
-  set: (value: number) => emit("update:nodeSize", value),
-});
-
-const labelScaleModel = computed({
-  get: () => props.labelScale,
-  set: (value: number) => emit("update:labelScale", value),
-});
-
-const showLabelsModel = computed({
-  get: () => props.showLabels,
-  set: (value: boolean) => emit("update:showLabels", value),
-});
 </script>


### PR DESCRIPTION
## Summary
- use `defineModel` for simpler two-way binding
- update App.vue to rely on v-model bindings and watchers
- adjust layout select to always emit updates

## Testing
- `npm run lint`
- `npm run check`
- `npm test -- --run`